### PR TITLE
Rename column-level "metadata" to "annotations"

### DIFF
--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -13,6 +13,6 @@ pub fn compile(schema_json: &str, dialect: &str, input: String) -> Result<String
     };
     let compiler = Compiler::new(schema_json, options)?;
     let result = compiler.compile(input.to_owned())?;
-    // Return a JSON object `{ sql, columnMetadata }` serialized as a string.
+    // Return a JSON object `{ sql, columnAnnotations }` serialized as a string.
     serde_json::to_string(&result).map_err(|e| e.to_string())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,7 @@ struct CompileArgs {
     #[arg(short, long)]
     schema: String,
     /// Output format. `sql` prints only the generated SQL. `json` prints a JSON object containing
-    /// the SQL along with the column metadata.
+    /// the SQL along with the column annotation.
     #[arg(short, long, value_enum, default_value_t = OutputFormat::Sql)]
     format: OutputFormat,
     /// The querydown query to execute. If empty, stdin will be used.

--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -8,7 +8,7 @@ mod rendering;
 mod result_columns;
 mod scope;
 
-use querydown_parser::ast::MetaValue;
+use querydown_parser::ast::AnnotationValue;
 use querydown_parser::parse;
 use serde::Serialize;
 
@@ -25,15 +25,15 @@ use self::{
     scope::Scope,
 };
 
-/// The output of compiling Querydown code: the generated SQL plus column-level metadata.
+/// The output of compiling Querydown code: the generated SQL plus column-level annotation.
 ///
-/// `column_metadata` is positionally aligned with the columns of the result set — one entry per
-/// output column, in order, with `null` for any column that has no metadata.
+/// `column_annotations` is positionally aligned with the columns of the result set — one entry per
+/// output column, in order, with `null` for any column that has no annotation.
 #[derive(Debug, Serialize)]
 pub struct CompileResult {
     pub sql: String,
-    #[serde(rename = "columnMetadata")]
-    pub column_metadata: Vec<Option<MetaValue>>,
+    #[serde(rename = "columnAnnotations")]
+    pub column_annotations: Vec<Option<AnnotationValue>>,
 }
 
 pub struct Compiler {
@@ -69,7 +69,7 @@ impl Compiler {
         let ConvertedResultColumns {
             columns,
             sorting: column_sorting,
-            column_metadata,
+            column_annotations,
         } = convert_result_columns(result_columns, &mut scope)?;
         select.columns = columns;
         // Standalone `\\` sorts take precedence over column `\s` sorts, hence they come first.
@@ -82,7 +82,7 @@ impl Compiler {
 
         Ok(CompileResult {
             sql: format!("{};", select.render(&mut scope)),
-            column_metadata,
+            column_annotations,
         })
     }
 }

--- a/compiler/src/compiler/result_columns.rs
+++ b/compiler/src/compiler/result_columns.rs
@@ -16,13 +16,13 @@ use self::sorting::SortingStack;
 
 use super::{expr::convert_expr, scope::Scope};
 
-/// The result of converting result columns: the SQL columns, the sorting, and a `column_metadata`
+/// The result of converting result columns: the SQL columns, the sorting, and a `column_annotations`
 /// vector that is positionally aligned with `columns` (one entry per emitted column, `None` where
-/// the column has no metadata).
+/// the column has no annotation).
 pub struct ConvertedResultColumns {
     pub columns: Vec<Column>,
     pub sorting: Vec<SortEntry>,
-    pub column_metadata: Vec<Option<MetaValue>>,
+    pub column_annotations: Vec<Option<AnnotationValue>>,
 }
 
 /// Converts standalone `\\` sorting expressions into SQL sort entries, preserving the order in
@@ -50,7 +50,7 @@ pub fn convert_result_columns(
     scope: &mut Scope,
 ) -> Result<ConvertedResultColumns, String> {
     let mut columns = Vec::<Column>::new();
-    let mut column_metadata = Vec::<Option<MetaValue>>::new();
+    let mut column_annotations = Vec::<Option<AnnotationValue>>::new();
     let mut sorting_stack = SortingStack::new();
     for column_statement in result_columns {
         match column_statement {
@@ -58,7 +58,7 @@ pub fn convert_result_columns(
                 handle_spec(
                     spec,
                     &mut columns,
-                    &mut column_metadata,
+                    &mut column_annotations,
                     &mut sorting_stack,
                     scope,
                 )?;
@@ -67,7 +67,7 @@ pub fn convert_result_columns(
                 handle_glob(
                     glob,
                     &mut columns,
-                    &mut column_metadata,
+                    &mut column_annotations,
                     &mut sorting_stack,
                     scope,
                 )?;
@@ -77,14 +77,14 @@ pub fn convert_result_columns(
     Ok(ConvertedResultColumns {
         columns,
         sorting: sorting_stack.into(),
-        column_metadata,
+        column_annotations,
     })
 }
 
 fn handle_spec(
     spec: ColumnSpec,
     columns: &mut Vec<Column>,
-    column_metadata: &mut Vec<Option<MetaValue>>,
+    column_annotations: &mut Vec<Option<AnnotationValue>>,
     sorting_stack: &mut SortingStack,
     scope: &mut Scope,
 ) -> Result<(), String> {
@@ -98,7 +98,7 @@ fn handle_spec(
         sorting_stack.push(sorting_expr, sort_spec);
     }
     columns.push(Column { expr, alias });
-    column_metadata.push(spec.metadata);
+    column_annotations.push(spec.annotation);
     // TODO convert GroupSpec into GROUP BY
     Ok(())
 }
@@ -106,7 +106,7 @@ fn handle_spec(
 fn handle_glob(
     glob: ColumnGlob,
     columns: &mut Vec<Column>,
-    column_metadata: &mut Vec<Option<MetaValue>>,
+    column_annotations: &mut Vec<Option<AnnotationValue>>,
     sorting_stack: &mut SortingStack,
     scope: &mut Scope,
 ) -> Result<(), String> {
@@ -147,7 +147,7 @@ fn handle_glob(
 
     let mut hidden_columns: HashSet<usize> = HashSet::new();
     let mut column_aliases: HashMap<usize, String> = HashMap::new();
-    let mut column_metadata_map: HashMap<usize, MetaValue> = HashMap::new();
+    let mut column_annotations_map: HashMap<usize, AnnotationValue> = HashMap::new();
 
     for spec in glob.specs {
         if let Expr::Path(ref path) = spec.expr {
@@ -163,8 +163,8 @@ fn handle_glob(
                 if let Some(alias) = spec.alias {
                     column_aliases.insert(column_id, alias);
                 }
-                if let Some(metadata) = spec.metadata {
-                    column_metadata_map.insert(column_id, metadata);
+                if let Some(annotation) = spec.annotation {
+                    column_annotations_map.insert(column_id, annotation);
                 }
             }
         }
@@ -175,7 +175,7 @@ fn handle_glob(
         let alias = column_aliases.get(&column.id).cloned();
         if !hidden_columns.contains(&column.id) {
             columns.push(Column { expr, alias });
-            column_metadata.push(column_metadata_map.get(&column.id).cloned());
+            column_annotations.push(column_annotations_map.get(&column.id).cloned());
         }
     }
     Ok(())

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -9,5 +9,5 @@ mod utils;
 
 pub use compiler::{CompileResult, Compiler};
 pub use options::{IdentifierResolution, Options};
-pub use querydown_parser::ast::MetaValue;
+pub use querydown_parser::ast::AnnotationValue;
 pub use sql::Postgres;

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -993,10 +993,10 @@ ORDER BY
   "issues"."title" DESC NULLS LAST;
 ```
 
-## Column metadata
+## Column annotations
 
 A test case may include an optional ` ```json ` block after the SQL block. When
-present, the harness compares its `columnMetadata` against the compiler output.
+present, the harness compares its `columnAnnotations` against the compiler output.
 
 ### Full example
 
@@ -1032,7 +1032,7 @@ LEFT JOIN "cte0" ON
 
 ```json
 {
-  "columnMetadata": [
+  "columnAnnotations": [
     { "width": 100 },
     { "formatter": "timeElapsed", "textColor": "light" },
     { "format": "YYYY-MM-DD", "datePicker": true },
@@ -1046,9 +1046,9 @@ LEFT JOIN "cte0" ON
 }
 ```
 
-### Null slot for a column without metadata
+### Null slot for a column without annotation
 
-> A column without metadata gets a `null` slot, keeping the array aligned with the columns.
+> A column without annotation gets a `null` slot, keeping the array aligned with the columns.
 
 ```qd
 #issues $title @{width:100} $id
@@ -1063,16 +1063,16 @@ FROM "issues";
 
 ```json
 {
-  "columnMetadata": [
+  "columnAnnotations": [
     { "width": 100 },
     null
   ]
 }
 ```
 
-### Metadata on a globbed column
+### Annotation on a globbed column
 
-> Metadata attached to a column inside a glob is associated with that one expanded column.
+> Annotation attached to a column inside a glob is associated with that one expanded column.
 
 ```qd
 #issues $*(title @{width:100})
@@ -1094,7 +1094,7 @@ FROM "issues";
 
 ```json
 {
-  "columnMetadata": [
+  "columnAnnotations": [
     null,
     { "width": 100 },
     null,

--- a/compiler/src/tests/corpus.rs
+++ b/compiler/src/tests/corpus.rs
@@ -105,7 +105,7 @@ fn test_corpus() {
 
     fn test(case: TestCase<Opts>) {
         // Args are the fenced code blocks in document order: the Querydown input first, then the
-        // expected SQL, then optionally a JSON block with the expected column metadata.
+        // expected SQL, then optionally a JSON block with the expected column annotation.
         let input = case.args.first().expect("missing input code block").clone();
         let expected_sql = case.args.get(1).expect("missing SQL code block").clone();
         let expected_json = case.args.get(2).cloned();
@@ -126,20 +126,20 @@ fn test_corpus() {
         }
 
         if let Some(expected_json) = expected_json {
-            // Compare only the `columnMetadata` portion, parsed into `serde_json::Value` so the
+            // Compare only the `columnAnnotations` portion, parsed into `serde_json::Value` so the
             // comparison is insensitive to whitespace.
-            let actual_meta = serde_json::to_value(&result.column_metadata).unwrap();
+            let actual_meta = serde_json::to_value(&result.column_annotations).unwrap();
             let expected_value: serde_json::Value = serde_json::from_str(&expected_json)
                 .expect("expected JSON block is not valid JSON");
             let expected_meta = expected_value
-                .get("columnMetadata")
+                .get("columnAnnotations")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null);
             if actual_meta != expected_meta {
                 let actual_str = serde_json::to_string_pretty(&actual_meta).unwrap();
                 let expected_str = serde_json::to_string_pretty(&expected_meta).unwrap();
                 println!("{}", get_output(&case, &input, &expected_str, &actual_str));
-                panic!("Test corpus failure (metadata mismatch)");
+                panic!("Test corpus failure (annotation mismatch)");
             }
         }
     }

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -34,7 +34,7 @@ _See the **[Language Guide](./language.md)** for more detail._
 | `"` or `'` | string quote | ✅ |
 | `^` | [string flag](./language.md#flagged-strings) prefix | ❌ |
 | `{ }` | [string interpolation](./language.md#flagged-strings) | ❌ |
-| `@{ }` | [column metadata](./language.md#column-level-metadata) object (`@true`/`@false`/`@null`, whitespace-delimited, `:` between key and value) | ✅ |
+| `@{ }` | [column annotations](./language.md#column-level-annotations) object (`@true`/`@false`/`@null`, whitespace-delimited, `:` between key and value) | ✅ |
 | `\` | string escape sequence prefix | ✅ |
 | `` ` `` | [identifier quote](./language.md#identifiers-table-names-and-column-names) | ✅ |
 
@@ -76,7 +76,7 @@ Regex flags
 | `->` | [alias](./language.md#aliasing-result-columns) prefix | ✅ |
 | `\` | column control flags prefix | ✅ |
 | `\\` | [sorting expression](./language.md#sorting-outside-of-result-columns) prefix (followed by optional `\d` / `\n` flags) | ✅ |
-| `@{ }` | [column metadata](./language.md#column-level-metadata) (written last in the spec) | ✅ |
+| `@{ }` | [column annotations](./language.md#column-level-annotations) (written last in the spec) | ✅ |
 
 Column control flags:
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -68,9 +68,9 @@ _Also see the **[Cheat Sheet](./cheat-sheet.md)** for a quicker reference._
   - [Table-scoped functions](#table-scoped-functions)
   - [Function call expansion](#function-call-expansion)
   - [User-defined tables](#user-defined-tables)
-- [Metadata](#metadata)
-  - [Column-level metadata](#column-level-metadata)
-  - [Query-level metadata](#query-level-metadata)
+- [Annotations](#annotations)
+  - [Column-level annotations](#column-level-annotations)
+  - [Query-level annotations](#query-level-annotations)
 - [Limit and offset](#limit-and-offset)
 - [Modules](#modules)
 
@@ -921,13 +921,13 @@ _(🚧 Not yet implemented)_
 #project_months issue_count:>=10 $project \g $%count
 ```
 
-## Metadata
+## Annotations
 
-### Column-level metadata
+### Column-level annotations
 
-You can associate arbitrary, application-defined metadata with any result column by writing an object prefixed with a `@` sigil. The metadata must come **last** in the column spec — after any sorting/grouping flags and after the column alias.
+You can associate arbitrary, application-defined annotations with any result column by writing an object prefixed with a `@` sigil. The annotation must come **last** in the column spec — after any sorting/grouping flags and after the column alias.
 
-> Show several columns from the `issues` table, attaching display metadata to each.
+> Show several columns from the `issues` table, attaching display annotations to each.
 
 ```qd
 #issues
@@ -939,11 +939,11 @@ $#comments @{formattingConditions:[
   {gte:5 bg:'#d5d2ff'}
 ]}
 ```
-In additon to the query SQL, this also produces the following metadata:
+In additon to the query SQL, this also produces the following annotations:
 
 ```json
 {
-  "columnMetadata": [
+  "columnAnnotations": [
     { "width": 100 },
     { "formatter": "timeElapsed", "textColor": "light" },
     { "format": "YYYY-MM-DD", "datePicker": true },
@@ -957,32 +957,32 @@ In additon to the query SQL, this also produces the following metadata:
 }
 ```
 
-The exact structure of the metadata is entirely up to you. Querydown does not interpret it — it only provides a way to specify arbitrary metadata for any column and pass it through to the output.
+The exact structure of the annotation is entirely up to you. Querydown does not interpret it — it only provides a way to specify arbitrary annotations for any column and pass them through to the output.
 
-#### The metadata output
+#### The annotation output
 
-The `columnMetadata` array is **positional**: it has one entry per output column, in the same order as the columns in the result set. A column with no metadata gets `null` in its slot. This means a column glob like `$*` contributes one `null` (or its adjustment metadata) per expanded column, and hidden columns (`\h`) contribute nothing.
+The `columnAnnotations` array is **positional**: it has one entry per output column, in the same order as the columns in the result set. A column with no annotation gets `null` in its slot. This means a column glob like `$*` contributes one `null` (or its adjustment annotation) per expanded column, and hidden columns (`\h`) contribute nothing.
 
 #### Querydown's JSON variant
 
-The metadata is written in a JSON-like syntax with a few differences from standard JSON:
+Annotations are written in a JSON-like syntax with a few differences from standard JSON:
 
 - Object entries and array elements are delimited with **whitespace** instead of commas.
 - Strings can be left **unquoted** if they are identifiers (e.g. `timeElapsed`). They can also be quoted with single or double quotes.
 - The values `null`, `true`, and `false` are written with a `@` sigil: `@null`, `@true`, `@false`.
-- Only the top-level metadata object takes the `@` sigil. Nested objects do not.
+- Only the top-level annotation object takes the `@` sigil. Nested objects do not.
 
 A few things to watch out for:
 
 - Bare `true`, `false`, and `null` (without the `@` sigil) are parsed as the **strings** `"true"`, `"false"`, and `"null"`.
-- Inside metadata, the `@` sigil accepts **only** `true`/`false`/`null` — not dates (`@2000-01-01`), durations (`@2y`), or other constants.
+- Inside an annotation, the `@` sigil accepts **only** `true`/`false`/`null` — not dates (`@2000-01-01`), durations (`@2y`), or other constants.
 - A value that begins with a digit is parsed as a number, and a value that begins with `#` (such as a color like `#fbc9ff`) must be quoted.
 
-### Query-level metadata
+### Query-level annotations
 
 _(🚧 Not yet implemented)_
 
-> Show all issues. Also associate `{"foo": 100}` as JSON metadata with the query. This metadata will get passed through as output from the Querydown compiler, separate from the SQL output.
+> Show all issues. Also associate `{"foo": 100}` as a JSON annotation with the query. This annotation will get passed through as output from the Querydown compiler, separate from the SQL output.
 
 ```qd
 #issues \\\{"foo": 100}

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -3,44 +3,44 @@ use serde::{Serialize, Serializer};
 
 use crate::tokens::LITERAL_NULL;
 
-/// A value in Querydown's JSON-like metadata sub-language. Used to carry arbitrary,
-/// application-defined metadata for result columns from the source code through to the compiler
+/// A value in Querydown's JSON-like annotation sub-language. Used to carry arbitrary,
+/// application-defined annotations for result columns from the source code through to the compiler
 /// output, separate from the generated SQL.
 #[derive(Debug, Clone, PartialEq)]
-pub enum MetaValue {
+pub enum AnnotationValue {
     Null,
     Bool(bool),
     /// The number is kept as a string (like [`Expr::Number`]) so that we preserve the exact way it
     /// was written. It is serialized as a JSON number.
     Number(String),
     String(String),
-    Array(Vec<MetaValue>),
+    Array(Vec<AnnotationValue>),
     /// Object entries are stored in a `Vec` (rather than a map) so that key order is preserved in
     /// the serialized output.
-    Object(Vec<(String, MetaValue)>),
+    Object(Vec<(String, AnnotationValue)>),
 }
 
-impl Serialize for MetaValue {
+impl Serialize for AnnotationValue {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         match self {
-            MetaValue::Null => serializer.serialize_none(),
-            MetaValue::Bool(b) => serializer.serialize_bool(*b),
-            MetaValue::Number(n) => {
+            AnnotationValue::Null => serializer.serialize_none(),
+            AnnotationValue::Bool(b) => serializer.serialize_bool(*b),
+            AnnotationValue::Number(n) => {
                 let number: serde_json::Number = n.parse().map_err(serde::ser::Error::custom)?;
                 number.serialize(serializer)
             }
-            MetaValue::String(s) => serializer.serialize_str(s),
-            MetaValue::Array(items) => {
+            AnnotationValue::String(s) => serializer.serialize_str(s),
+            AnnotationValue::Array(items) => {
                 let mut seq = serializer.serialize_seq(Some(items.len()))?;
                 for item in items {
                     seq.serialize_element(item)?;
                 }
                 seq.end()
             }
-            MetaValue::Object(entries) => {
+            AnnotationValue::Object(entries) => {
                 let mut map = serializer.serialize_map(Some(entries.len()))?;
                 for (key, value) in entries {
                     map.serialize_entry(key, value)?;
@@ -313,9 +313,9 @@ pub struct ColumnSpec {
     pub expr: Expr,
     pub alias: Option<String>,
     pub column_control: ColumnControl,
-    /// Optional column-level metadata, written last in the spec as `@{ ... }`. When present, this
-    /// is always a [`MetaValue::Object`].
-    pub metadata: Option<MetaValue>,
+    /// Optional column-level annotation, written last in the spec as `@{ ... }`. When present, this
+    /// is always a [`AnnotationValue::Object`].
+    pub annotation: Option<AnnotationValue>,
 }
 
 #[derive(Debug, PartialEq, Default)]
@@ -366,8 +366,8 @@ pub struct ColumnGlob {
 mod tests {
     use super::*;
 
-    fn obj(entries: Vec<(&str, MetaValue)>) -> MetaValue {
-        MetaValue::Object(
+    fn obj(entries: Vec<(&str, AnnotationValue)>) -> AnnotationValue {
+        AnnotationValue::Object(
             entries
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
@@ -379,17 +379,20 @@ mod tests {
     fn test_meta_value_serialization() {
         // Numbers are unquoted, booleans are real JSON booleans, null is null, and object key order
         // is preserved.
-        let value = MetaValue::Array(vec![
-            obj(vec![("width", MetaValue::Number("100".to_string()))]),
+        let value = AnnotationValue::Array(vec![
+            obj(vec![("width", AnnotationValue::Number("100".to_string()))]),
             obj(vec![
-                ("formatter", MetaValue::String("timeElapsed".to_string())),
-                ("textColor", MetaValue::String("light".to_string())),
+                (
+                    "formatter",
+                    AnnotationValue::String("timeElapsed".to_string()),
+                ),
+                ("textColor", AnnotationValue::String("light".to_string())),
             ]),
             obj(vec![
-                ("format", MetaValue::String("YYYY-MM-DD".to_string())),
-                ("datePicker", MetaValue::Bool(true)),
+                ("format", AnnotationValue::String("YYYY-MM-DD".to_string())),
+                ("datePicker", AnnotationValue::Bool(true)),
             ]),
-            obj(vec![("missing", MetaValue::Null)]),
+            obj(vec![("missing", AnnotationValue::Null)]),
         ]);
         let json = serde_json::to_string(&value).unwrap();
         assert_eq!(
@@ -400,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_meta_value_float_serialization() {
-        let value = MetaValue::Number("-2.5".to_string());
+        let value = AnnotationValue::Number("-2.5".to_string());
         assert_eq!(serde_json::to_string(&value).unwrap(), "-2.5");
     }
 }

--- a/parser/src/parser/annotation.rs
+++ b/parser/src/parser/annotation.rs
@@ -5,28 +5,28 @@ use crate::tokens::*;
 
 use super::utils::*;
 
-/// Parses column-level metadata: a top-level object introduced by `@`, e.g. `@{width:100}`.
+/// Parses a column-level annotation: a top-level object introduced by `@`, e.g. `@{width:100}`.
 ///
-/// The metadata sub-language is a JSON-like variant in which:
+/// The annotation sub-language is a JSON-like variant in which:
 /// - object entries and array elements are whitespace-delimited (no commas),
 /// - strings may be left unquoted if they are identifiers,
 /// - and the values `null`, `true`, and `false` are written with a `@` sigil.
 ///
 /// The top level must be an object. Nested objects do not take the `@` sigil.
-pub fn metadata<'src>() -> impl Psr<'src, MetaValue> {
+pub fn annotation<'src>() -> impl Psr<'src, AnnotationValue> {
     just(CONST_SIGIL).ignore_then(object(value()))
 }
 
-/// A recursive parser for any metadata value (object, array, number, string, or `@`-constant).
-fn value<'src>() -> impl Psr<'src, MetaValue> {
+/// A recursive parser for any annotation value (object, array, number, string, or `@`-constant).
+fn value<'src>() -> impl Psr<'src, AnnotationValue> {
     recursive(|value| {
         // `@true`, `@false`, and `@null`. Note that only these three constants are permitted here
         // — unlike elsewhere in the language, `@`-prefixed dates, durations, and other constants
-        // are intentionally not accepted, because metadata must be JSON-representable.
+        // are intentionally not accepted, because annotations must be JSON-representable.
         let constant = just(CONST_SIGIL).ignore_then(choice((
-            exactly(LITERAL_TRUE).to(MetaValue::Bool(true)),
-            exactly(LITERAL_FALSE).to(MetaValue::Bool(false)),
-            exactly(LITERAL_NULL).to(MetaValue::Null),
+            exactly(LITERAL_TRUE).to(AnnotationValue::Bool(true)),
+            exactly(LITERAL_FALSE).to(AnnotationValue::Bool(false)),
+            exactly(LITERAL_NULL).to(AnnotationValue::Null),
         )));
 
         let number = just('-')
@@ -34,26 +34,26 @@ fn value<'src>() -> impl Psr<'src, MetaValue> {
             .then(int(10))
             .then(just('.').then(digits(10)).or_not())
             .to_slice()
-            .map(|s: &str| MetaValue::Number(s.to_string()));
+            .map(|s: &str| AnnotationValue::Number(s.to_string()));
 
         let quoted_string = quoted(STRING_QUOTE_SINGLE)
             .or(quoted(STRING_QUOTE_DOUBLE))
-            .map(MetaValue::String);
+            .map(AnnotationValue::String);
 
         // An unquoted identifier is treated as a string. This is also why bare `true`/`false`/
         // `null` (without the `@` sigil) parse as the strings `"true"`/`"false"`/`"null"`.
-        let ident_string = ident().map(|s: &str| MetaValue::String(s.to_string()));
+        let ident_string = ident().map(|s: &str| AnnotationValue::String(s.to_string()));
 
         let array = value
             .clone()
             .padded()
             .repeated()
-            .collect::<Vec<MetaValue>>()
+            .collect::<Vec<AnnotationValue>>()
             .delimited_by(
                 just(CONDITION_SET_OR_BRACE_L),
                 just(CONDITION_SET_OR_BRACE_R),
             )
-            .map(MetaValue::Array);
+            .map(AnnotationValue::Array);
 
         choice((
             object(value),
@@ -66,43 +66,43 @@ fn value<'src>() -> impl Psr<'src, MetaValue> {
     })
 }
 
-/// Parses a metadata object `{ key:value ... }` given a parser for its values. Used both for the
+/// Parses an annotation object `{ key:value ... }` given a parser for its values. Used both for the
 /// top-level object and for nested objects.
-fn object<'src>(value: impl Psr<'src, MetaValue>) -> impl Psr<'src, MetaValue> {
+fn object<'src>(value: impl Psr<'src, AnnotationValue>) -> impl Psr<'src, AnnotationValue> {
     let key = ident()
         .map(|s: &str| s.to_string())
         .or(quoted(STRING_QUOTE_SINGLE))
         .or(quoted(STRING_QUOTE_DOUBLE));
 
     let entry = key
-        .then_ignore(just(METADATA_KEY_VALUE_SEPARATOR).padded())
+        .then_ignore(just(ANNOTATION_KEY_VALUE_SEPARATOR).padded())
         .then(value);
 
     entry
         .padded()
         .repeated()
-        .collect::<Vec<(String, MetaValue)>>()
+        .collect::<Vec<(String, AnnotationValue)>>()
         .delimited_by(
             just(CONDITION_SET_AND_BRACE_L),
             just(CONDITION_SET_AND_BRACE_R),
         )
-        .map(MetaValue::Object)
+        .map(AnnotationValue::Object)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn p(s: &str) -> Result<MetaValue, ()> {
-        metadata()
+    fn p(s: &str) -> Result<AnnotationValue, ()> {
+        annotation()
             .then_ignore(end())
             .parse(s)
             .into_result()
             .map_err(|_| ())
     }
 
-    fn obj(entries: Vec<(&str, MetaValue)>) -> MetaValue {
-        MetaValue::Object(
+    fn obj(entries: Vec<(&str, AnnotationValue)>) -> AnnotationValue {
+        AnnotationValue::Object(
             entries
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
@@ -110,12 +110,12 @@ mod tests {
         )
     }
 
-    fn num(n: &str) -> MetaValue {
-        MetaValue::Number(n.to_string())
+    fn num(n: &str) -> AnnotationValue {
+        AnnotationValue::Number(n.to_string())
     }
 
-    fn s(v: &str) -> MetaValue {
-        MetaValue::String(v.to_string())
+    fn s(v: &str) -> AnnotationValue {
+        AnnotationValue::String(v.to_string())
     }
 
     #[test]
@@ -128,12 +128,15 @@ mod tests {
         );
         assert_eq!(p("@{a:'foo'}"), Ok(obj(vec![("a", s("foo"))])));
         assert_eq!(p("@{a:\"foo\"}"), Ok(obj(vec![("a", s("foo"))])));
-        assert_eq!(p("@{a:@true}"), Ok(obj(vec![("a", MetaValue::Bool(true))])));
+        assert_eq!(
+            p("@{a:@true}"),
+            Ok(obj(vec![("a", AnnotationValue::Bool(true))]))
+        );
         assert_eq!(
             p("@{a:@false}"),
-            Ok(obj(vec![("a", MetaValue::Bool(false))]))
+            Ok(obj(vec![("a", AnnotationValue::Bool(false))]))
         );
-        assert_eq!(p("@{a:@null}"), Ok(obj(vec![("a", MetaValue::Null)])));
+        assert_eq!(p("@{a:@null}"), Ok(obj(vec![("a", AnnotationValue::Null)])));
         // Bare `true` (without the sigil) is a string.
         assert_eq!(p("@{a:true}"), Ok(obj(vec![("a", s("true"))])));
     }
@@ -160,7 +163,7 @@ mod tests {
             p("@{formattingConditions:[\n  {gte:10 bg:'#fbc9ff'}\n  {gte:5 bg:'#d5d2ff'}\n]}"),
             Ok(obj(vec![(
                 "formattingConditions",
-                MetaValue::Array(vec![
+                AnnotationValue::Array(vec![
                     obj(vec![("gte", num("10")), ("bg", s("#fbc9ff"))]),
                     obj(vec![("gte", num("5")), ("bg", s("#d5d2ff"))]),
                 ])

--- a/parser/src/parser/column_layout.rs
+++ b/parser/src/parser/column_layout.rs
@@ -3,8 +3,8 @@ use chumsky::{prelude::*, text::*};
 use crate::ast::*;
 use crate::tokens::*;
 
+use super::annotation::annotation;
 use super::expr::{expr, path_to_one};
-use super::metadata::metadata;
 use super::utils::*;
 
 pub fn result_columns<'src>() -> impl Psr<'src, Vec<ResultColumnStatement>> {
@@ -63,14 +63,14 @@ fn column_spec<'src>() -> impl Psr<'src, ColumnSpec> {
                 )
                 .or_not(),
         )
-        // Metadata must come last in the spec — after the sorting/grouping flags and after the
+        // Annotation must come last in the spec — after the sorting/grouping flags and after the
         // alias.
-        .then(whitespace().ignore_then(metadata()).or_not())
-        .map(|(((expr, alias), ctrl), metadata)| ColumnSpec {
+        .then(whitespace().ignore_then(annotation()).or_not())
+        .map(|(((expr, alias), ctrl), annotation)| ColumnSpec {
             expr,
             alias,
             column_control: ctrl.unwrap_or_default(),
-            metadata,
+            annotation,
         })
 }
 
@@ -189,7 +189,7 @@ mod tests {
                 column_control: ColumnControl::default(),
                 expr: Expr::Number("8".to_string()),
                 alias: None,
-                metadata: None,
+                annotation: None,
             })
         );
         assert_eq!(
@@ -207,14 +207,14 @@ mod tests {
                 },
                 expr: Expr::Path(vec![PathPart::Column("foo".to_string())]),
                 alias: Some("bar".to_string()),
-                metadata: None,
+                annotation: None,
             })
         );
     }
 
     #[test]
-    fn test_parse_column_spec_with_metadata() {
-        // Metadata is parsed after the alias and after the column control flags.
+    fn test_parse_column_spec_with_annotation() {
+        // Annotation is parsed after the alias and after the column control flags.
         assert_eq!(
             column_spec()
                 .then_ignore(end())
@@ -233,17 +233,17 @@ mod tests {
                 },
                 expr: Expr::Path(vec![PathPart::Column("foo".to_string())]),
                 alias: Some("bar".to_string()),
-                metadata: Some(MetaValue::Object(vec![(
+                annotation: Some(AnnotationValue::Object(vec![(
                     "width".to_string(),
-                    MetaValue::Number("100".to_string())
+                    AnnotationValue::Number("100".to_string())
                 )])),
             })
         );
     }
 
     #[test]
-    fn test_metadata_must_come_last() {
-        // Metadata before the column control flags is not allowed.
+    fn test_annotation_must_come_last() {
+        // Annotation before the column control flags is not allowed.
         assert!(column_spec()
             .then_ignore(end())
             .parse(r"foo @{width:100}\sd")
@@ -273,7 +273,7 @@ mod tests {
                             },
                             expr: Expr::Path(vec![PathPart::Column("c".to_string())]),
                             alias: None,
-                            metadata: None,
+                            annotation: None,
                         },
                         ColumnSpec {
                             column_control: ColumnControl {
@@ -288,7 +288,7 @@ mod tests {
                             },
                             expr: Expr::Path(vec![PathPart::Column("d".to_string())]),
                             alias: None,
-                            metadata: None,
+                            annotation: None,
                         },
                     ]
                 }),
@@ -296,7 +296,7 @@ mod tests {
                     column_control: ColumnControl::default(),
                     expr: Expr::Path(vec![PathPart::Column("foo".to_string())]),
                     alias: None,
-                    metadata: None,
+                    annotation: None,
                 }),
                 ResultColumnStatement::Spec(ColumnSpec {
                     column_control: ColumnControl {
@@ -307,7 +307,7 @@ mod tests {
                     },
                     expr: Expr::Path(vec![PathPart::Column("bar".to_string())]),
                     alias: Some("B".to_string()),
-                    metadata: None,
+                    annotation: None,
                 }),
             ])
         );

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -1,6 +1,6 @@
+mod annotation;
 mod column_layout;
 mod expr;
-mod metadata;
 mod query;
 mod sorting;
 mod utils;

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -91,7 +91,7 @@ mod tests {
                             is_hidden: false
                         },
                         expr: Expr::Path(vec![PathPart::Column("c".to_string())]),
-                        metadata: None,
+                        annotation: None,
                     })],
                 }],
             })

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -44,8 +44,8 @@ pub(crate) const HAS_QUANTITY_ZERO: &str = "--";
 pub(crate) const LITERAL_NULL: &str = "null";
 pub(crate) const LITERAL_TRUE: &str = "true";
 pub(crate) const LITERAL_FALSE: &str = "false";
-/// Separates a key from its value within a metadata object entry, e.g. the `:` in `@{width:100}`.
-pub(crate) const METADATA_KEY_VALUE_SEPARATOR: char = ':';
+/// Separates a key from its value within an annotation object entry, e.g. the `:` in `@{width:100}`.
+pub(crate) const ANNOTATION_KEY_VALUE_SEPARATOR: char = ':';
 /// Prefix for boolean negation of an expression, e.g. `!foo:2` or `!is_deleted`.
 pub(crate) const NEGATE: char = '!';
 pub(crate) const PATH_SEPARATOR: char = '.';

--- a/site/src/routes/(fit-viewport)/playground/Playground.svelte
+++ b/site/src/routes/(fit-viewport)/playground/Playground.svelte
@@ -54,7 +54,7 @@
     function handle_change() {
       let sql = '';
       try {
-        // `compile` returns a JSON string of `{ sql, columnMetadata }`. The playground only
+        // `compile` returns a JSON string of `{ sql, columnAnnotations }`. The playground only
         // displays the SQL for now.
         const result = JSON.parse(compile(schema_code, 'postgres', qd_code));
         sql = result.sql;


### PR DESCRIPTION
Renames the column-level "metadata" feature terminology to "annotation"/"annotations" across all code and docs, including public interfaces (as requested, even where it breaks them).

## Public interface changes (breaking)
- `MetaValue` → `AnnotationValue` (re-exported from the compiler crate)
- `ColumnSpec.metadata` → `ColumnSpec.annotation`
- JSON output key `columnMetadata` → `columnAnnotations` (backing field `CompileResult.column_metadata` → `column_annotations`)

## Internal changes
- `parser/src/parser/metadata.rs` → `annotation.rs`; `mod metadata` → `mod annotation`; parser fn `metadata()` → `annotation()`
- `METADATA_KEY_VALUE_SEPARATOR` → `ANNOTATION_KEY_VALUE_SEPARATOR`
- Compiler locals/maps renamed (`column_metadata` → `column_annotations`, `column_metadata_map` → `column_annotations_map`)

## Docs & misc
- `docs/language.md`: section/heading/anchor renames (`## Annotations`, `#column-level-annotations`, `#query-level-annotations`) plus prose tidied so "annotation(s)" reads naturally as a countable noun
- `docs/cheat-sheet.md`, `compiler/src/tests/corpus.md`, and the playground comment updated

A repo-wide search confirms zero remaining `metadata` references.

## Validation
All passing: `cargo check`, `cargo clippy`, `cargo build`, `cargo test`, `cargo fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0142JSzNe3PW563HThYNEBz7)_