### PR TITLE
Add ORDER BY support to aggregate functions; switch list to array_agg

### DIFF
--- a/compiler/src/compiler/functions.rs
+++ b/compiler/src/compiler/functions.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use querydown_parser::ast::{Call, Expr, FunctionDimension};
+use querydown_parser::ast::{Call, Expr, FunctionDimension, SortExpr};
 
 use crate::{
     compiler::{
@@ -17,7 +17,9 @@ use crate::{
 pub fn convert_call(call: Call, scope: &mut Scope) -> Result<SqlExpr, String> {
     match call.dimension {
         FunctionDimension::Scalar => convert_scalar_call(&call.name, call.args, scope),
-        FunctionDimension::Aggregate => convert_aggregate_call(&call.name, call.args, scope),
+        FunctionDimension::Aggregate => {
+            convert_aggregate_call(&call.name, call.args, call.order_by, scope)
+        }
     }
 }
 
@@ -28,15 +30,23 @@ fn convert_scalar_call(name: &str, e: Vec<Expr>, s: &mut Scope) -> Result<SqlExp
     func(e, s)
 }
 
-fn convert_aggregate_call(name: &str, e: Vec<Expr>, s: &mut Scope) -> Result<SqlExpr, String> {
+fn convert_aggregate_call(
+    name: &str,
+    e: Vec<Expr>,
+    order_by: Vec<SortExpr>,
+    s: &mut Scope,
+) -> Result<SqlExpr, String> {
     let func = s
         .get_aggregate_function(name)
         .ok_or_else(|| unknown_aggregate_function(name))?;
-    func(e, s)
+    func(e, order_by, s)
 }
 
-pub type FuncMap = HashMap<String, Func>;
-pub type Func = fn(Vec<Expr>, &mut Scope) -> Result<SqlExpr, String>;
+pub type ScalarFuncMap = HashMap<String, ScalarFunc>;
+pub type ScalarFunc = fn(Vec<Expr>, &mut Scope) -> Result<SqlExpr, String>;
+
+pub type AggregateFuncMap = HashMap<String, AggregateFunc>;
+pub type AggregateFunc = fn(Vec<Expr>, Vec<SortExpr>, &mut Scope) -> Result<SqlExpr, String>;
 
 /// Get the first item out of an Iterator, ensuring it has no more
 fn iter_one<T>(items: impl IntoIterator<Item = T>) -> Option<T> {
@@ -89,9 +99,9 @@ fn args_2(
     Ok(f(convert_expr(a, scope)?, convert_expr(b, scope)?))
 }
 
-pub fn get_standard_scalar_functions() -> FuncMap {
+pub fn get_standard_scalar_functions() -> ScalarFuncMap {
     #[rustfmt::skip]
-    let templates: [(&str, Func); 24] = [
+    let templates: [(&str, ScalarFunc); 24] = [
         ("abs",         |e, s| args_1(e, s, abs)),
         ("age",         |e, s| args_1(e, s, |a| subtract(now(), a))),
         ("ago",         |e, s| args_1(e, s, |a| subtract(now(), a))),
@@ -126,8 +136,9 @@ pub fn get_standard_scalar_functions() -> FuncMap {
 /// Used for an aggregate function that takes one argument
 fn agg_1(
     args: Vec<Expr>,
+    order_by: Vec<SortExpr>,
     scope: &mut Scope,
-    agg_wrapper: fn(SqlExpr) -> SqlExpr,
+    agg_wrapper: fn(SqlExpr, String) -> SqlExpr,
 ) -> Result<SqlExpr, String> {
     let arg0 = iter_one(args).ok_or_else(msg::expected_one_arg)?;
     let Expr::Path(path_parts) = arg0 else {
@@ -142,7 +153,7 @@ fn agg_1(
     let Some(column_name) = column_name_opt else {
         return Err(msg::aggregate_fn_applied_to_a_path_without_a_column());
     };
-    let aggregate_expr_template = AggregateExprTemplate::new(column_name, agg_wrapper);
+    let aggregate_expr_template = AggregateExprTemplate::new(column_name, agg_wrapper, order_by);
     scope.join_chain_to_many(
         &clarified_path.head,
         chain_to_many,
@@ -151,18 +162,18 @@ fn agg_1(
     )
 }
 
-pub fn get_standard_aggregate_functions() -> FuncMap {
+pub fn get_standard_aggregate_functions() -> AggregateFuncMap {
     #[rustfmt::skip]
-    let templates: [(&str, Func); 9] = [
-        ("all_true", |e, s| agg_1(e, s, bool_and)),
-        ("any_true", |e, s| agg_1(e, s, bool_or)),
-        ("avg",      |e, s| agg_1(e, s, avg)),
-        ("count",    |e, s| agg_1(e, s, count)),
-        ("distinct", |e, s| agg_1(e, s, count_distinct)),
-        ("list",     |e, s| agg_1(e, s, string_agg)),
-        ("max",      |e, s| agg_1(e, s, max)),
-        ("min",      |e, s| agg_1(e, s, min)),
-        ("sum",      |e, s| agg_1(e, s, sum)),
+    let templates: [(&str, AggregateFunc); 9] = [
+        ("all_true", |e, ob, s| agg_1(e, ob, s, bool_and)),
+        ("any_true", |e, ob, s| agg_1(e, ob, s, bool_or)),
+        ("avg",      |e, ob, s| agg_1(e, ob, s, avg)),
+        ("count",    |e, ob, s| agg_1(e, ob, s, count)),
+        ("distinct", |e, ob, s| agg_1(e, ob, s, count_distinct)),
+        ("list",     |e, ob, s| agg_1(e, ob, s, array_agg)),
+        ("max",      |e, ob, s| agg_1(e, ob, s, max)),
+        ("min",      |e, ob, s| agg_1(e, ob, s, min)),
+        ("sum",      |e, ob, s| agg_1(e, ob, s, sum)),
     ];
     templates
         .into_iter()

--- a/compiler/src/compiler/paths/ctes.rs
+++ b/compiler/src/compiler/paths/ctes.rs
@@ -1,7 +1,9 @@
+use querydown_parser::ast::{NullsSort, SortDirection, SortExpr};
+
 use crate::{
     compiler::{
         constants::{CTE_PK_COLUMN_ALIAS, CTE_VALUE_COLUMN_PREFIX},
-        expr::convert_condition_set,
+        expr::{convert_condition_set, convert_expr},
         join_tree::make_join_from_link,
         scope::Scope,
     },
@@ -24,28 +26,51 @@ pub struct ValueViaCte {
 
 pub struct AggregateExprTemplate {
     column_name: String,
-    /// This is a function that accepts a table.column expression and returns a wrapped expression
-    /// that is used as the aggregate expression. E.g. it might be:
+    /// This is a function that accepts a table.column expression and a pre-rendered ORDER BY
+    /// clause (empty string when no ORDER BY was specified) and returns a wrapped expression
+    /// that is used as the aggregate expression. E.g. it might produce:
     ///
-    /// ```rs
-    /// fn max(a: SqlExpr) -> SqlExpr {
-    ///     SqlExpr::atom(format!("max({})", a))
-    /// }
-    /// ```
+    /// `array_agg("col" ORDER BY "col" ASC NULLS LAST)`
     ///
     /// When this AggregateExprTemplate instance is rendered within a CTE, the column_name is
     /// resolved to a table.column expression, and then the agg_wrapper is applied to that
-    /// expression.
-    agg_wrapper: fn(SqlExpr) -> SqlExpr,
+    /// expression along with the compiled ORDER BY string.
+    agg_wrapper: fn(SqlExpr, String) -> SqlExpr,
+    order_by: Vec<SortExpr>,
 }
 
 impl AggregateExprTemplate {
-    pub fn new(column_name: String, agg_wrapper: fn(SqlExpr) -> SqlExpr) -> Self {
+    pub fn new(
+        column_name: String,
+        agg_wrapper: fn(SqlExpr, String) -> SqlExpr,
+        order_by: Vec<SortExpr>,
+    ) -> Self {
         Self {
             column_name,
             agg_wrapper,
+            order_by,
         }
     }
+}
+
+fn render_order_by(order_by: Vec<SortExpr>, scope: &mut Scope) -> Result<String, String> {
+    if order_by.is_empty() {
+        return Ok(String::new());
+    }
+    let mut parts = Vec::with_capacity(order_by.len());
+    for sort_expr in order_by {
+        let sql_expr = convert_expr(sort_expr.expr, scope)?;
+        let direction = match sort_expr.direction {
+            SortDirection::Asc => "ASC",
+            SortDirection::Desc => "DESC",
+        };
+        let nulls_sort = match sort_expr.nulls_sort {
+            NullsSort::First => "NULLS FIRST",
+            NullsSort::Last => "NULLS LAST",
+        };
+        parts.push(format!("{} {} {}", sql_expr, direction, nulls_sort));
+    }
+    Ok(parts.join(", "))
 }
 
 pub fn build_cte_select(
@@ -112,8 +137,16 @@ pub fn build_cte_select(
                     .ok_or_else(|| msg::col_not_in_table(&column_name, &ending_table.name))?;
                 let column = ending_table.columns.get(column_id).unwrap();
                 let reference = cte_scope.table_column_expr(&ending_table.name, &column.name);
+                let order_by_str = {
+                    let mut ob_scope = cte_scope.spawn(ending_table);
+                    let s = render_order_by(template.order_by, &mut ob_scope)?;
+                    let (ob_joins, ob_ctes) = ob_scope.decompose_join_tree();
+                    select.joins.extend(ob_joins);
+                    select.ctes.extend(ob_ctes);
+                    s
+                };
                 let wrapper = template.agg_wrapper;
-                wrapper(reference)
+                wrapper(reference, order_by_str)
             }
             None => build::agg::count_star(),
         };

--- a/compiler/src/compiler/scope.rs
+++ b/compiler/src/compiler/scope.rs
@@ -14,7 +14,10 @@ use crate::{
 
 use super::{
     constants::*,
-    functions::{get_standard_aggregate_functions, get_standard_scalar_functions, Func, FuncMap},
+    functions::{
+        get_standard_aggregate_functions, get_standard_scalar_functions, AggregateFunc,
+        AggregateFuncMap, ScalarFunc, ScalarFuncMap,
+    },
     join_tree::JoinTree,
     paths::{build_cte_select, AggregateExprTemplate, ValueViaCte},
 };
@@ -28,8 +31,8 @@ pub struct Scope<'a, 'b> {
     pub path_prefix: Vec<PathPart>,
     aliases: HashSet<String>,
     cte_naming_index: usize,
-    scalar_functions: FuncMap,
-    aggregate_functions: FuncMap,
+    scalar_functions: ScalarFuncMap,
+    aggregate_functions: AggregateFuncMap,
 }
 
 impl<'a, 'b> Scope<'a, 'b> {
@@ -192,14 +195,14 @@ impl<'a, 'b> Scope<'a, 'b> {
         get_table_by_name(self.options, self.schema, name)
     }
 
-    pub fn get_scalar_function(&self, name: &str) -> Option<&Func> {
+    pub fn get_scalar_function(&self, name: &str) -> Option<&ScalarFunc> {
         self.scalar_functions.get(name).or_else(|| {
             self.parent
                 .and_then(|parent| parent.get_scalar_function(name))
         })
     }
 
-    pub fn get_aggregate_function(&self, name: &str) -> Option<&Func> {
+    pub fn get_aggregate_function(&self, name: &str) -> Option<&AggregateFunc> {
         self.aggregate_functions.get(name).or_else(|| {
             self.parent
                 .and_then(|parent| parent.get_aggregate_function(name))

--- a/compiler/src/sql/expr/build.rs
+++ b/compiler/src/sql/expr/build.rs
@@ -22,51 +22,62 @@ pub fn sql_func(name: &str, args: impl IntoIterator<Item = SqlExpr>) -> SqlExpr 
 pub mod agg {
     use super::*;
 
-    pub fn bool_and(a: SqlExpr) -> SqlExpr {
-        sql_func("bool_and", [a])
+    fn with_order(name: &str, a: SqlExpr, order_by: String) -> SqlExpr {
+        if order_by.is_empty() {
+            sql_func(name, [a])
+        } else {
+            SqlExpr::atom(format!("{}({} ORDER BY {})", name, a.content, order_by))
+        }
     }
 
-    pub fn bool_or(a: SqlExpr) -> SqlExpr {
-        sql_func("bool_or", [a])
+    pub fn array_agg(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("array_agg", a, order_by)
     }
 
-    pub fn avg(a: SqlExpr) -> SqlExpr {
-        sql_func("avg", [a])
+    pub fn bool_and(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("bool_and", a, order_by)
     }
 
-    pub fn count(a: SqlExpr) -> SqlExpr {
-        sql_func("count", [a])
+    pub fn bool_or(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("bool_or", a, order_by)
+    }
+
+    pub fn avg(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("avg", a, order_by)
+    }
+
+    pub fn count(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("count", a, order_by)
     }
 
     pub fn count_star() -> SqlExpr {
         SqlExpr::atom("count(*)".to_string())
     }
 
-    pub fn count_distinct(a: SqlExpr) -> SqlExpr {
+    pub fn count_distinct(a: SqlExpr, order_by: String) -> SqlExpr {
         // TODO: We should alter the query at a higher level to use an approach like this for
         // better performance:
         // https://stackoverflow.com/questions/11250253/postgresql-countdistinct-very-slow
-        SqlExpr::atom(format!("count(DISTINCT {})", a.content))
+        if order_by.is_empty() {
+            SqlExpr::atom(format!("count(DISTINCT {})", a.content))
+        } else {
+            SqlExpr::atom(format!(
+                "count(DISTINCT {} ORDER BY {})",
+                a.content, order_by
+            ))
+        }
     }
 
-    pub fn max(a: SqlExpr) -> SqlExpr {
-        sql_func("max", [a])
+    pub fn max(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("max", a, order_by)
     }
 
-    pub fn min(a: SqlExpr) -> SqlExpr {
-        sql_func("min", [a])
+    pub fn min(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("min", a, order_by)
     }
 
-    pub fn string_agg(a: SqlExpr) -> SqlExpr {
-        // TODO:
-        // - Let user customize the separator
-        // - Use dialect-specific string quoting logic
-        let separator = SqlExpr::atom("', '".to_string());
-        sql_func("string_agg", [a, separator])
-    }
-
-    pub fn sum(a: SqlExpr) -> SqlExpr {
-        sql_func("sum", [a])
+    pub fn sum(a: SqlExpr, order_by: String) -> SqlExpr {
+        with_order("sum", a, order_by)
     }
 }
 

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -669,6 +669,87 @@ LEFT JOIN "cte0" ON
   "projects"."id" = "cte0"."pk";
 ```
 
+### List aggregate (array_agg)
+
+> Issues with an array of their label names.
+
+```qd
+#issues $id $#issue_labels.label.name%list
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "issue_labels"."issue" AS "pk",
+      array_agg("labels"."name") AS "v1"
+    FROM "issue_labels"
+    JOIN "labels" ON
+      "issue_labels"."label" = "labels"."id"
+    GROUP BY "issue_labels"."issue"
+  )
+SELECT
+  "issues"."id",
+  "cte0"."v1"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk";
+```
+
+### List aggregate with ORDER BY
+
+> Issues with an array of their label names sorted alphabetically.
+
+```qd
+#issues $id $#issue_labels.label.name%list(\\name)
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "issue_labels"."issue" AS "pk",
+      array_agg("labels"."name" ORDER BY "labels"."name" ASC NULLS LAST) AS "v1"
+    FROM "issue_labels"
+    JOIN "labels" ON
+      "issue_labels"."label" = "labels"."id"
+    GROUP BY "issue_labels"."issue"
+  )
+SELECT
+  "issues"."id",
+  "cte0"."v1"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk";
+```
+
+### List aggregate with descending ORDER BY
+
+> Issues with an array of their label names sorted reverse-alphabetically.
+
+```qd
+#issues $id $#issue_labels.label.name%list(\\name \d)
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "issue_labels"."issue" AS "pk",
+      array_agg("labels"."name" ORDER BY "labels"."name" DESC NULLS LAST) AS "v1"
+    FROM "issue_labels"
+    JOIN "labels" ON
+      "issue_labels"."label" = "labels"."id"
+    GROUP BY "issue_labels"."issue"
+  )
+SELECT
+  "issues"."id",
+  "cte0"."v1"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk";
+```
+
 ### Multiple CTEs
 
 > Issues that have comments and assignments

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -66,7 +66,7 @@ pub struct Transformation {
 
 /// A standalone sorting expression, written with the `\\` prefix outside of the result columns,
 /// e.g. `\\created_at \d`. The order in which these are listed defines their sort precedence.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SortExpr {
     pub expr: Expr,
     pub direction: SortDirection,
@@ -288,6 +288,7 @@ pub struct Call {
     pub dimension: FunctionDimension,
     pub args: Vec<Expr>,
     pub syntax: CallSyntax,
+    pub order_by: Vec<SortExpr>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -461,13 +461,16 @@ mod tests {
                                 dimension: FunctionDimension::Scalar,
                                 syntax: CallSyntax::Piped,
                                 args: vec![Expr::Number("1".to_string())],
+                                order_by: vec![],
                             }),
                             Expr::Number("2".to_string())
                         ],
+                        order_by: vec![],
                     }),
                     Expr::Number("3".to_string()),
                     Expr::Number("4".to_string()),
                 ],
+                order_by: vec![],
             }))
         );
 
@@ -491,6 +494,7 @@ mod tests {
                             dimension: FunctionDimension::Scalar,
                             syntax: CallSyntax::Piped,
                             args: vec![Expr::Variable("bar".to_string())],
+                            order_by: vec![],
                         })),
                     )),
                 )),

--- a/parser/src/parser/expr/pipe.rs
+++ b/parser/src/parser/expr/pipe.rs
@@ -1,38 +1,84 @@
 use chumsky::{prelude::*, text::*};
 
 use crate::ast::*;
+use crate::parser::sorting::sort_flags;
 use crate::parser::utils::*;
 use crate::tokens::*;
+
+fn agg_sort_expr<'src>(expr_parser: impl Psr<'src, Expr>) -> impl Psr<'src, SortExpr> {
+    just(SORT_EXPR_PREFIX)
+        .ignore_then(whitespace())
+        .ignore_then(expr_parser)
+        .then(whitespace().ignore_then(sort_flags()).or_not())
+        .map(|(expr, flags)| {
+            let (direction, nulls_sort) = flags.unwrap_or_default();
+            SortExpr {
+                expr,
+                direction,
+                nulls_sort,
+            }
+        })
+}
 
 pub fn pipe<'src>(
     arg0_expr: impl Psr<'src, Expr>,
     extra_args_expr: impl Psr<'src, Expr>,
 ) -> impl Psr<'src, Expr> {
-    let args = just(COMPOSITION_ARGUMENT_BRACE_L)
-        .ignore_then(extra_args_expr.padded().repeated().collect::<Vec<Expr>>())
+    let scalar_args = just(COMPOSITION_ARGUMENT_BRACE_L)
+        .ignore_then(
+            extra_args_expr
+                .clone()
+                .padded()
+                .repeated()
+                .collect::<Vec<Expr>>(),
+        )
         .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R));
 
-    let dimension = choice((
-        just(COMPOSITION_PIPE_SCALAR).to(FunctionDimension::Scalar),
-        just(COMPOSITION_PIPE_AGGREGATE).to(FunctionDimension::Aggregate),
-    ));
+    let aggregate_order_by = just(COMPOSITION_ARGUMENT_BRACE_L)
+        .ignore_then(
+            agg_sort_expr(extra_args_expr)
+                .padded()
+                .repeated()
+                .collect::<Vec<SortExpr>>(),
+        )
+        .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R));
+
+    let scalar_call = just(COMPOSITION_PIPE_SCALAR)
+        .padded()
+        .ignore_then(ident())
+        .then(scalar_args.or_not())
+        .map(|(name, extra_args)| {
+            (
+                FunctionDimension::Scalar,
+                name.to_string(),
+                extra_args.unwrap_or_default(),
+                vec![],
+            )
+        });
+
+    let aggregate_call = just(COMPOSITION_PIPE_AGGREGATE)
+        .padded()
+        .ignore_then(ident())
+        .then(aggregate_order_by.or_not())
+        .map(|(name, order_by)| {
+            (
+                FunctionDimension::Aggregate,
+                name.to_string(),
+                vec![],
+                order_by.unwrap_or_default(),
+            )
+        });
 
     arg0_expr.foldl(
-        dimension
-            .padded()
-            .then(ident())
-            .then(args.or_not())
-            .repeated(),
-        |arg0, ((dimension, name), extra_args)| {
-            let args = vec![arg0]
-                .into_iter()
-                .chain(extra_args.unwrap_or_default())
-                .collect();
+        choice((scalar_call, aggregate_call)).repeated(),
+        |arg0, (dimension, name, extra_args, order_by)| {
+            let args = std::iter::once(arg0).chain(extra_args).collect();
             Expr::Call(Call {
-                name: name.to_string(),
+                name,
                 dimension,
                 syntax: CallSyntax::Piped,
                 args,
+                order_by,
             })
         },
     )

--- a/parser/src/parser/sorting.rs
+++ b/parser/src/parser/sorting.rs
@@ -34,7 +34,7 @@ fn sort_expr<'src>() -> impl Psr<'src, SortExpr> {
 /// Parses the optional `\d` / `\n` flags that may follow a standalone sorting expression. Only `d`
 /// (descending) and `n` (nulls first) are accepted — `s` is implied by the `\\` prefix. Flags may
 /// be combined within a single backslash group, e.g. `\dn`.
-fn sort_flags<'src>() -> impl Psr<'src, (SortDirection, NullsSort)> {
+pub(crate) fn sort_flags<'src>() -> impl Psr<'src, (SortDirection, NullsSort)> {
     #[derive(Clone)]
     enum Flag {
         Desc,


### PR DESCRIPTION
## Summary

- **`list` now uses `array_agg`** instead of `string_agg`, producing proper SQL arrays
- **ORDER BY inside aggregate functions** using the same `\\expr \flags` sort syntax as standalone sort conditions, e.g. `$#labels.name%list(\\name \d)` produces `array_agg("labels"."name" ORDER BY "labels"."name" DESC NULLS LAST)`
- ORDER BY is accepted at the parser level for **all** aggregate functions and passed through to SQL even where semantically it has no effect (consistent with both PostgreSQL and DuckDB behavior)

## Key design decisions

- ORDER BY expressions inside `%func(\\...)` are resolved in the scope of the **ending table** of the aggregate path, so a bare `\\name` refers to the column on the aggregated table rather than the base table
- The ORDER BY string is pre-rendered to `String` in `ctes.rs` before being passed to the `agg_wrapper` function to avoid a circular dependency between `sql::expr` and `sql::tree`
- `agg_wrapper` functions now have signature `fn(SqlExpr, String) -> SqlExpr` where the second arg is the pre-rendered ORDER BY clause (empty string = no ORDER BY)

## Test plan

- [ ] Corpus tests pass: `cargo test --package querydown`
- [ ] Parser tests pass: `cargo test --package querydown-parser`
- [ ] `list` without ORDER BY: `$#labels.name%list` → `array_agg("labels"."name")`
- [ ] `list` with ascending ORDER BY: `%list(\\name)` → `array_agg("labels"."name" ORDER BY "labels"."name" ASC NULLS LAST)`
- [ ] `list` with descending ORDER BY: `%list(\\name \d)` → `array_agg("labels"."name" ORDER BY "labels"."name" DESC NULLS LAST)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cTETqWHQS94ioeP2BsJ9U

---
_Generated by [Claude Code](https://claude.ai/code/session_019cTETqWHQS94ioeP2BsJ9U)_