### PR TITLE
Parse bare text on comparison RHS as a string literal

### DIFF
--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -468,6 +468,26 @@ WHERE
   COALESCE(strpos(lower("issues"."title" COLLATE "C"), lower('performance' COLLATE "C")) > 0, FALSE);
 ```
 
+### Text match (contains, bare word on right-hand side)
+
+A bare (unquoted) word on the right-hand side of a comparison is a string literal, so this is
+equivalent to quoting `performance`. To refer to a column on the right-hand side instead, the
+identifier can be quoted with backticks or written as a multi-part path.
+
+> Issues whose title contains "performance", written without quotes
+
+```qd
+#issues title:performance
+```
+
+```sql
+SELECT
+  "issues".*
+FROM "issues"
+WHERE
+  COALESCE(strpos(lower("issues"."title" COLLATE "C"), lower('performance' COLLATE "C")) > 0, FALSE);
+```
+
 ### Text match (contains, DuckDB)
 
 ```toml options

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -62,6 +62,8 @@ _See the **[Language Guide](./language.md)** for more detail._
 | `:\c~` | match regex with flags | ❌ |
 | `:~~` | LIKE | ❌ |
 
+A bare (unquoted) word on the right-hand-side of a comparison is a [string literal](./language.md#bare-text-on-the-right-hand-side-of-a-comparison), e.g. `title:performance` is the same as `title:"performance"`. Quote it with backticks to reference a column instead.
+
 The `!` operator negates any comparison (or expression) e.g. `!foo:2`
 
 Regex flags

--- a/docs/language.md
+++ b/docs/language.md
@@ -111,6 +111,7 @@ Base table          Conditions               Result columns       */
     - begin with a lowercase letter or uppercase letter or underscore
     - include only letters, numbers, and underscores.
 - Unlike SQL, column names like `group` and `year` don't need quotes because there are no keywords and functions names are always clear to the parser from other syntax.
+- Note that a bare (unquoted) word on the [right-hand-side of a comparison](#bare-text-on-the-right-hand-side-of-a-comparison) is parsed as a string literal, not a column reference. Use backticks there if you need to reference a column.
 
 ### Flexible identifiers
 
@@ -346,6 +347,23 @@ The `:` comparison operator (aka "match") behaves differently according to the t
 - Other values (e.g. numbers, dates, etc) are compared using strict equality.
 
 If you need to search text values using exact equality, use the `:=` comparison instead of the match comparison.
+
+### Bare text on the right-hand-side of a comparison
+
+A bare (unquoted) word on the **right-hand-side** of a comparison is interpreted as a **string literal** rather than a column reference. This matches the behavior you may expect from tools like GitHub.
+
+> Find issues where the title contains the word "performance"
+
+```qd
+#issues title:performance
+```
+
+The query above is equivalent to `#issues title:"performance"`.
+
+This only applies to the right-hand-side. Bare text elsewhere (e.g. on the left-hand-side) continues to be parsed as a column reference. If you need to reference a column on the right-hand-side, you can either:
+
+- quote the identifier with backticks, e.g. ``#issues description:`title` ``, or
+- write it as a multi-part path, e.g. `#issues description:foo.bar`.
 
 ### All comparison operators
 

--- a/parser/src/parser/expr/comparison.rs
+++ b/parser/src/parser/expr/comparison.rs
@@ -6,7 +6,8 @@ use crate::parser::utils::*;
 use crate::tokens::*;
 
 pub fn comparison<'src>(
-    comparison_side_expr: impl Psr<'src, Expr>,
+    left_side_expr: impl Psr<'src, Expr>,
+    right_side_expr: impl Psr<'src, Expr>,
     condition_set_expr: impl Psr<'src, Expr>,
     range_expr: impl Psr<'src, Expr>,
 ) -> impl Psr<'src, Comparison> {
@@ -15,14 +16,14 @@ pub fn comparison<'src>(
             .then_ignore(pad().then(just(COMPARISON_EXPAND)))
             .map(ComparisonSide::Expansion),
         range(range_expr.clone()).map(ComparisonSide::Range),
-        comparison_side_expr.clone().map(ComparisonSide::Expr),
+        left_side_expr.map(ComparisonSide::Expr),
     ));
     let right = choice((
         just(COMPARISON_EXPAND)
             .then(pad())
-            .ignore_then(condition_set(condition_set_expr.clone()).map(ComparisonSide::Expansion)),
-        range(range_expr.clone()).map(ComparisonSide::Range),
-        comparison_side_expr.clone().map(ComparisonSide::Expr),
+            .ignore_then(condition_set(condition_set_expr).map(ComparisonSide::Expansion)),
+        range(range_expr).map(ComparisonSide::Range),
+        right_side_expr.map(ComparisonSide::Expr),
     ));
 
     left.then(operator().padded_by(pad()))

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -67,10 +67,38 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
 
         let prec_addition = addition(prec_multiplication).boxed();
 
-        let prec_comparison = comparison(prec_addition.clone(), prec_comma, prec_atom)
-            .map(|c| Expr::Comparison(Box::new(c)))
-            .or(prec_addition)
-            .boxed();
+        // The right-hand side of a comparison uses a parallel precedence chain that is identical to
+        // the one above in every respect except its atom: a bare (unquoted) word on the right-hand
+        // side is interpreted as a string literal rather than a column reference. See
+        // `comparison_rhs_value` for details.
+        let prec_atom_rhs = choice((
+            number().map(Expr::Number),
+            date().map(Expr::Date),
+            duration().map(Expr::Duration),
+            string().map(Expr::String),
+            variable().map(Expr::Variable),
+            comparison_rhs_value(prec_comma.clone()),
+            has_quantity(prec_comma.clone()).map(Expr::HasQuantity),
+            condition_set(prec_comma.clone()).map(Expr::ConditionSet),
+            parenthetical(prec_comma.clone()),
+        ))
+        .boxed();
+
+        let prec_pipe_rhs = pipe(prec_atom_rhs, prec_comma.clone()).boxed();
+
+        let prec_multiplication_rhs = multiplication(prec_pipe_rhs).boxed();
+
+        let prec_addition_rhs = addition(prec_multiplication_rhs).boxed();
+
+        let prec_comparison = comparison(
+            prec_addition.clone(),
+            prec_addition_rhs,
+            prec_comma,
+            prec_atom,
+        )
+        .map(|c| Expr::Comparison(Box::new(c)))
+        .or(prec_addition)
+        .boxed();
 
         let prec_negation = negation(prec_comparison).boxed();
 
@@ -118,6 +146,22 @@ fn variable<'src>() -> impl Psr<'src, String> {
 
 fn string<'src>() -> impl Psr<'src, String> {
     quoted(STRING_QUOTE_SINGLE).or(quoted(STRING_QUOTE_DOUBLE))
+}
+
+/// Parses the value on the right-hand side of a comparison, where a bare (unquoted) word is
+/// interpreted as a string literal rather than a column reference. This matches the behavior users
+/// expect from tools like GitHub, where e.g. `description:title` searches for the literal text
+/// "title". To refer to a column on the right-hand side, the identifier can either be quoted with
+/// backticks (e.g. `` `title` ``) or written as a multi-part path (e.g. `foo.bar`).
+///
+/// A bare word is only treated as a string when it stands alone. If it is the head of a longer path
+/// (e.g. `foo.bar`), the whole path is parsed as a column reference instead. Everywhere other than
+/// the right-hand side of a comparison, bare words continue to be parsed as column references.
+fn comparison_rhs_value<'src>(expr: impl Psr<'src, Expr>) -> impl Psr<'src, Expr> {
+    let bare_string = ident()
+        .then_ignore(pad().then(just(PATH_SEPARATOR)).not())
+        .map(|s: &str| Expr::String(s.to_string()));
+    choice((bare_string, path(expr).map(Expr::Path)))
 }
 
 fn parenthetical<'src>(e: impl Psr<'src, Expr>) -> impl Psr<'src, Expr> {
@@ -494,7 +538,8 @@ mod tests {
                 right: ComparisonSide::Expr(Expr::Sum(
                     Box::new(Expr::Number("2".to_string())),
                     Box::new(Expr::Product(
-                        Box::new(Expr::Path(vec![PathPart::Column("foo".to_string())])),
+                        // A bare word on the right-hand side of a comparison is a string literal.
+                        Box::new(Expr::String("foo".to_string())),
                         Box::new(Expr::Call(Call {
                             name: "baz".to_string(),
                             dimension: FunctionDimension::Scalar,
@@ -559,6 +604,75 @@ mod tests {
                     })),
                 ]
             }))
+        );
+    }
+
+    #[test]
+    fn test_bare_text_on_comparison_rhs_is_a_string() {
+        let p = |s: &str| {
+            expr()
+                .then_ignore(end())
+                .parse(s)
+                .into_result()
+                .map_err(|_| ())
+        };
+
+        // A bare word on the left-hand side of a comparison is a column reference, while a bare
+        // word on the right-hand side is a string literal.
+        assert_eq!(
+            p("description:title"),
+            Ok(Expr::Comparison(Box::new(Comparison {
+                left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                    "description".to_string()
+                )])),
+                operator: Operator::Match,
+                right: ComparisonSide::Expr(Expr::String("title".to_string())),
+            })))
+        );
+
+        // A bare word on the right-hand side behaves identically to a quoted string.
+        assert_eq!(p("description:title"), p("description:\"title\""));
+
+        // Backtick-quoting the right-hand side designates it as a column reference instead.
+        assert_eq!(
+            p("description:`title`"),
+            Ok(Expr::Comparison(Box::new(Comparison {
+                left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                    "description".to_string()
+                )])),
+                operator: Operator::Match,
+                right: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                    "title".to_string()
+                )])),
+            })))
+        );
+
+        // A multi-part path on the right-hand side remains a column reference, since it is not a
+        // bare, standalone word.
+        assert_eq!(
+            p("description:foo.bar"),
+            Ok(Expr::Comparison(Box::new(Comparison {
+                left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                    "description".to_string()
+                )])),
+                operator: Operator::Match,
+                right: ComparisonSide::Expr(Expr::Path(vec![
+                    PathPart::Column("foo".to_string()),
+                    PathPart::Column("bar".to_string()),
+                ])),
+            })))
+        );
+
+        // The rule applies to other comparison operators too, not just match.
+        assert_eq!(
+            p("status:=open"),
+            Ok(Expr::Comparison(Box::new(Comparison {
+                left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                    "status".to_string()
+                )])),
+                operator: Operator::Eq,
+                right: ComparisonSide::Expr(Expr::String("open".to_string())),
+            })))
         );
     }
 }


### PR DESCRIPTION
## Summary

Changes how "bare text" on the **right-hand side of a comparison** is parsed. Previously a query like `#issues description:title` parsed `title` as a column identifier (finding issues where the description contains the issue's title). Now bare text on the RHS is parsed as a **string literal**, so `#issues description:title` finds issues whose description contains the literal word "title" — equivalent to `#issues description:"title"`.

This matches the behavior users expect from tools like GitHub.

### Rules

- Bare text on the **right-hand side** of a comparison → string literal.
- Bare text **elsewhere** (e.g. left-hand side) → column reference, unchanged.
- To reference a column on the RHS, the user can:
  - quote the identifier with backticks (e.g. ``description:`title` ``), or
  - write a multi-part path (e.g. `description:foo.bar`).

A bare word is only treated as a string when it stands alone. If it's the head of a longer path (e.g. `foo.bar`), the whole path is parsed as a column reference.

## Implementation

- `parser/src/parser/expr/comparison.rs`: `comparison()` now takes separate parsers for the left and right sides.
- `parser/src/parser/expr/mod.rs`: added a parallel precedence chain for the RHS whose atom uses a new `comparison_rhs_value` helper that interprets a standalone bare word as a string literal (backtick-quoted and multi-part identifiers remain column references).

## Tests

- New unit test `test_bare_text_on_comparison_rhs_is_a_string` in the parser covering: bare word → string, equivalence to a quoted string, backtick → column, multi-part path → column, and a non-match operator (`:=`).
- Updated an existing parser test where a bare word appears inside RHS arithmetic.
- New end-to-end corpus case showing `#issues title:performance` compiles to the same SQL as the quoted form.

## Validation

`cargo check`, `cargo clippy`, `cargo build`, `cargo test`, and `cargo fmt` all pass. The `--features db-tests` suite could not run in this environment because the Postgres `initdb` binary is not available in the container (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVGZwknTdRSywWT5ZFS6ZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVGZwknTdRSywWT5ZFS6ZA)_