### PR TITLE
Implement case expressions

### DIFF
--- a/compiler/src/compiler/expr.rs
+++ b/compiler/src/compiler/expr.rs
@@ -26,6 +26,7 @@ pub fn convert_expr(expr: Expr, scope: &mut Scope) -> Result<SqlExpr, String> {
         Expr::Path(p) => convert_path(p, scope),
         Expr::ConditionSet(cs) => convert_condition_set(cs, scope),
         Expr::HasQuantity(h) => convert_has_quantity(h, scope),
+        Expr::Case(c) => convert_case(c, scope),
         Expr::Call(c) => convert_call(c, scope),
         Expr::Product(a, b) => Ok(math::multiply(
             convert_expr(*a, scope)?,
@@ -103,6 +104,17 @@ pub fn convert_condition_set(
         .map(|expr| convert_expr(expr, scope))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(cmp::condition_set(conditions, &condition_set.conjunction))
+}
+
+fn convert_case(case: Case, scope: &mut Scope) -> Result<SqlExpr, String> {
+    let mut variants = Vec::with_capacity(case.variants.len());
+    for variant in case.variants {
+        let condition = convert_expr(variant.condition, scope)?;
+        let value = convert_expr(variant.value, scope)?;
+        variants.push((condition, value));
+    }
+    let fallback = convert_expr(*case.fallback, scope)?;
+    Ok(cond::case(variants, fallback))
 }
 
 fn convert_has_quantity(has_quantity: HasQuantity, scope: &mut Scope) -> Result<SqlExpr, String> {

--- a/compiler/src/sql/expr/build.rs
+++ b/compiler/src/sql/expr/build.rs
@@ -158,6 +158,22 @@ pub mod cmp {
 pub mod cond {
     use super::*;
 
+    /// Build a searched `CASE` expression. Each `(condition, value)` pair becomes a `WHEN ... THEN
+    /// ...` arm, and `fallback` becomes the `ELSE`. The syntax is identical for Postgres and DuckDB.
+    ///
+    /// The result is atomic (delimited by `CASE`/`END`), so it never needs parenthesizing.
+    pub fn case(variants: Vec<(SqlExpr, SqlExpr)>, fallback: SqlExpr) -> SqlExpr {
+        let mut content = String::from("CASE");
+        for (condition, value) in variants {
+            content.push_str(&format!(
+                "\n  WHEN {} THEN {}",
+                condition.content, value.content
+            ));
+        }
+        content.push_str(&format!("\n  ELSE {}\nEND", fallback.content));
+        SqlExpr::atom(content)
+    }
+
     pub fn coalesce(a: SqlExpr) -> SqlExpr {
         sql_func("COALESCE", [a])
     }

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -542,6 +542,96 @@ WHERE
   "issues"."title" IS NULL;
 ```
 
+## Case expressions
+
+### Basic case expression
+
+> Categorize each issue by its status.
+
+```qd
+#issues
+$title
+$ ? status:="open"   ~ "Open"
+    status:="closed" ~ "Closed"
+    ~~                 "Other"
+->category
+```
+
+```sql
+SELECT
+  "issues"."title",
+  CASE
+    WHEN "issues"."status" = 'open' THEN 'Open'
+    WHEN "issues"."status" = 'closed' THEN 'Closed'
+    ELSE 'Other'
+  END AS "category"
+FROM "issues";
+```
+
+### Case expression with comparison conditions
+
+> Bucket each issue by its id.
+
+```qd
+#issues $ ? id:<10 ~ "low" id:<100 ~ "medium" ~~ "high" ->bucket
+```
+
+```sql
+SELECT
+  CASE
+    WHEN "issues"."id" < 10 THEN 'low'
+    WHEN "issues"."id" < 100 THEN 'medium'
+    ELSE 'high'
+  END AS "bucket"
+FROM "issues";
+```
+
+### Case expression with computed values
+
+> The conditions and the values can each be any expression, including computed ones.
+
+```qd
+#issues $id $ ? id:<10 ~ id * 2 ~~ id ->v
+```
+
+```sql
+SELECT
+  "issues"."id",
+  CASE
+    WHEN "issues"."id" < 10 THEN "issues"."id" * 2
+    ELSE "issues"."id"
+  END AS "v"
+FROM "issues";
+```
+
+### Case expression (DuckDB)
+
+```toml options
+dialect = "duckdb"
+```
+
+> The `CASE` syntax is identical for Postgres and DuckDB.
+
+```qd
+#issues
+$title
+$ ? status:="open"   ~ "Open"
+    status:="closed" ~ "Closed"
+    ~~                 "Other"
+->category
+```
+
+```sql
+SELECT
+  "issues"."title",
+  CASE
+    WHEN "issues"."status" = 'open' THEN 'Open'
+    WHEN "issues"."status" = 'closed' THEN 'Closed'
+    ELSE 'Other'
+  END AS "category"
+FROM "issues";
+```
+
 ## Condition sets
 
 ### "Has some" with "OR"

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -104,9 +104,9 @@ See [case expressions](./language.md#case-expressions) docs.
 
 | Code | Usage | Implemented |
 | -- | -- | -- |
-| `?` | if | ❌ |
-| `~` | then (can occur many times without nesting) | ❌ |
-| `~~` | else | ❌ |
+| `?` | if | ✅ |
+| `~` | then (can occur many times without nesting) | ✅ |
+| `~~` | else | ✅ |
 
 ## Functions
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -217,11 +217,11 @@ Functions can be applied to values via `|` (pipe) syntax.
 
 ### Case expressions
 
-_(🚧 Not yet implemented)_
-
 - `?` begins a case expression.
 - `~` denotes a case variant and separates a test expression (first) from a corresponding value expression (second).
 - `~~` prefixes the fallback value and indicates the end of the case expression.
+
+A case expression requires at least one variant and a fallback. It compiles to a SQL searched `CASE` expression, evaluating the variants in order and yielding the value of the first variant whose test expression is true, or the fallback if none are. The test expressions, value expressions, and fallback may each be any expression.
 
 > Categorize each issue into being either "overdue", "due soon", or "due later".
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -83,6 +83,7 @@ pub enum Expr {
     Path(Vec<PathPart>),
     ConditionSet(ConditionSet),
     HasQuantity(HasQuantity),
+    Case(Case),
     Call(Call),
     Product(Box<Expr>, Box<Expr>),
     Quotient(Box<Expr>, Box<Expr>),
@@ -285,6 +286,22 @@ pub struct HasQuantity {
 pub enum Quantity {
     AtLeastOne,
     Zero,
+}
+
+/// A case expression, e.g. `? a:1 ~ "one" a:2 ~ "two" ~~ "other"`. Each [`CaseVariant`] pairs a
+/// condition with a value; the `fallback` supplies the value used when no condition matches. This
+/// compiles to a SQL searched `CASE` expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Case {
+    pub variants: Vec<CaseVariant>,
+    pub fallback: Box<Expr>,
+}
+
+/// One `condition ~ value` arm of a [`Case`] expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CaseVariant {
+    pub condition: Expr,
+    pub value: Expr,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/parser/src/parser/expr/case.rs
+++ b/parser/src/parser/expr/case.rs
@@ -1,0 +1,153 @@
+use chumsky::prelude::*;
+
+use crate::ast::*;
+use crate::parser::utils::*;
+use crate::tokens::*;
+
+/// Parses a case expression, e.g.
+///
+/// ```text
+/// ? status:="open"   ~ "Open"
+///   status:="closed" ~ "Closed"
+///   ~~                 "Other"
+/// ```
+///
+/// A case begins with `?`, followed by one or more variants. Each variant pairs a condition
+/// expression (before the `~`) with a value expression (after it). The expression ends with `~~`
+/// followed by a fallback value used when no condition matches.
+///
+/// The `expr` parser passed in is the fully general expression parser, so conditions, values, and
+/// the fallback may each be any expression. A variant's leading condition can't begin with `~`, so
+/// the trailing `~~ fallback` is never mistaken for another variant.
+pub fn case<'src>(expr: impl Psr<'src, Expr>) -> impl Psr<'src, Case> {
+    let variant = expr
+        .clone()
+        .then_ignore(pad())
+        .then_ignore(just(CASE_VARIANT_SEPARATOR))
+        .then_ignore(pad())
+        .then(expr.clone())
+        .map(|(condition, value)| CaseVariant { condition, value });
+
+    just(CASE_BEGIN)
+        .ignore_then(pad())
+        .ignore_then(
+            variant
+                .then_ignore(pad())
+                .repeated()
+                .at_least(1)
+                .collect::<Vec<CaseVariant>>(),
+        )
+        .then_ignore(exactly(CASE_FALLBACK))
+        .then_ignore(pad())
+        .then(expr)
+        .map(|(variants, fallback)| Case {
+            variants,
+            fallback: Box::new(fallback),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::expr::expr;
+
+    fn parse(s: &str) -> Result<Expr, ()> {
+        expr()
+            .then_ignore(end())
+            .parse(s)
+            .into_result()
+            .map_err(|_| ())
+    }
+
+    fn col(name: &str) -> Expr {
+        Expr::Path(vec![PathPart::Column(name.to_string())])
+    }
+
+    fn str_(s: &str) -> Expr {
+        Expr::String(s.to_string())
+    }
+
+    fn match_eq(left: &str, right: Expr) -> Expr {
+        Expr::Comparison(Box::new(Comparison {
+            left: ComparisonSide::Expr(col(left)),
+            operator: Operator::Eq,
+            right: ComparisonSide::Expr(right),
+        }))
+    }
+
+    #[test]
+    fn test_single_variant() {
+        assert_eq!(
+            parse(r#"? is_active ~ "yes" ~~ "no""#),
+            Ok(Expr::Case(Case {
+                variants: vec![CaseVariant {
+                    condition: col("is_active"),
+                    value: str_("yes"),
+                }],
+                fallback: Box::new(str_("no")),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_multiple_variants() {
+        // Whitespace (including newlines) between the parts is insignificant.
+        let input = "?\n  status:=\"open\"   ~ \"Open\"\n  status:=\"closed\" ~ \"Closed\"\n  ~~                 \"Other\"";
+        assert_eq!(
+            parse(input),
+            Ok(Expr::Case(Case {
+                variants: vec![
+                    CaseVariant {
+                        condition: match_eq("status", str_("open")),
+                        value: str_("Open"),
+                    },
+                    CaseVariant {
+                        condition: match_eq("status", str_("closed")),
+                        value: str_("Closed"),
+                    },
+                ],
+                fallback: Box::new(str_("Other")),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_numeric_values() {
+        assert_eq!(
+            parse("? is_active ~ 1 ~~ 0"),
+            Ok(Expr::Case(Case {
+                variants: vec![CaseVariant {
+                    condition: col("is_active"),
+                    value: Expr::Number("1".to_string()),
+                }],
+                fallback: Box::new(Expr::Number("0".to_string())),
+            }))
+        );
+    }
+
+    #[test]
+    fn test_fallback_is_required() {
+        // Without the `~~` fallback the expression is incomplete.
+        assert!(parse(r#"? is_active ~ "yes""#).is_err());
+    }
+
+    #[test]
+    fn test_at_least_one_variant_required() {
+        assert!(parse(r#"? ~~ "no""#).is_err());
+    }
+
+    #[test]
+    fn test_case_in_parentheses() {
+        // A case expression can be nested inside other expressions when parenthesized.
+        assert_eq!(
+            parse(r#"(? is_active ~ "yes" ~~ "no")"#),
+            Ok(Expr::Case(Case {
+                variants: vec![CaseVariant {
+                    condition: col("is_active"),
+                    value: str_("yes"),
+                }],
+                fallback: Box::new(str_("no")),
+            }))
+        );
+    }
+}

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -1,3 +1,4 @@
+mod case;
 mod comparison;
 mod condition_set;
 mod date;
@@ -16,8 +17,8 @@ use crate::parser::utils::*;
 use crate::tokens::*;
 
 use self::{
-    comparison::comparison, condition_set::condition_set, date::date, duration::duration,
-    has_quantity::has_quantity, number::number, path::path, pipe::pipe,
+    case::case, comparison::comparison, condition_set::condition_set, date::date,
+    duration::duration, has_quantity::has_quantity, number::number, path::path, pipe::pipe,
 };
 
 pub fn expr<'src>() -> impl Psr<'src, Expr> {
@@ -56,6 +57,7 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
             variable().map(Expr::Variable),
             path(prec_comma.clone()).map(Expr::Path),
             has_quantity(prec_comma.clone()).map(Expr::HasQuantity),
+            case(prec_comma.clone()).map(Expr::Case),
             condition_set(prec_comma.clone()).map(Expr::ConditionSet),
             parenthetical(prec_comma.clone()),
         ))

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -1,3 +1,8 @@
+pub(crate) const CASE_BEGIN: char = '?';
+/// Separates a case variant's condition (first) from its value (second), e.g. the `~` in `a:1 ~ "x"`.
+pub(crate) const CASE_VARIANT_SEPARATOR: char = '~';
+/// Prefixes the fallback value of a case expression and marks its end, e.g. the `~~` in `~~ "other"`.
+pub(crate) const CASE_FALLBACK: &str = "~~";
 pub(crate) const COLUMN_ALIAS_PREFIX: &str = "->";
 pub(crate) const COLUMN_CONTROL_FLAG_DESC: char = 'd';
 pub(crate) const COLUMN_CONTROL_FLAG_GROUP: char = 'g';


### PR DESCRIPTION
## Summary

Implements case expressions as already documented in the language reference. A case expression begins with `?`, pairs each variant's condition with a value using `~`, and ends with a required fallback introduced by `~~`:

```qd
#issues
$title
$ ? status:="open"   ~ "Open"
    status:="closed" ~ "Closed"
    ~~                 "Other"
->category
```

This compiles to a SQL searched `CASE`:

```sql
CASE
  WHEN "issues"."status" = 'open' THEN 'Open'
  WHEN "issues"."status" = 'closed' THEN 'Closed'
  ELSE 'Other'
END AS "category"
```

The generated `CASE WHEN ... THEN ... ELSE ... END` syntax is identical for Postgres and DuckDB.

## Changes

- **Parser**: new `Case`/`CaseVariant` AST nodes (`parser/src/ast.rs`), tokens for `?`, `~`, `~~` (`parser/src/tokens.rs`), and a new `case` parser rule (`parser/src/parser/expr/case.rs`) wired in at the atom precedence level. The case is self-delimited; its conditions, values, and fallback may each be any expression. At least one variant and a fallback are required.
- **Compiler**: a new `cond::case` SQL builder (`compiler/src/sql/expr/build.rs`) and `convert_case` (`compiler/src/compiler/expr.rs`).
- **Tests**: parser unit tests in `case.rs` and four E2E corpus cases (basic, comparison conditions, computed values, and a DuckDB case asserting identical SQL).
- **Docs**: removed the "not yet implemented" note in `docs/language.md`, added a behavior note, and marked `?`/`~`/`~~` implemented in `docs/cheat-sheet.md`.

## Validation

`cargo check`, `cargo clippy`, `cargo build`, `cargo test`, and `cargo fmt` all pass.

⚠️ `cargo test --features db-tests` could **not** be run in this environment because the `initdb`/`pg_ctl`/`postgres`/`duckdb` binaries aren't available here (only the `psql` client). The generated SQL is standard ANSI `CASE`, valid and identical on both engines; the new DuckDB corpus case asserts the identical output. Please run the db-tests in the dev container to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vvxr3gC5zMdtfdh4THb3sJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vvxr3gC5zMdtfdh4THb3sJ)_