### PR TITLE
Implement grouping and aggregation

### DIFF
--- a/compiler/src/compiler/functions.rs
+++ b/compiler/src/compiler/functions.rs
@@ -6,11 +6,13 @@ use querydown_parser::ast::{Call, Expr, FunctionDimension, SortExpr};
 use crate::{
     compiler::{
         expr::convert_expr,
-        paths::{clarify_path, AggregateExprTemplate, ClarifiedPathTail},
+        paths::{
+            clarify_path, render_order_by, AggregateExprTemplate, ClarifiedPath, ClarifiedPathTail,
+        },
         scope::Scope,
     },
     errors::msg::{self, unknown_aggregate_function, unknown_scalar_function},
-    sql::expr::build::{agg::*, cond::*, date_time::*, func::*, math::*, strings::*},
+    sql::expr::build::{self, agg::*, cond::*, date_time::*, func::*, math::*, strings::*},
     sql::tree::{CtePurpose, SqlExpr},
 };
 
@@ -36,6 +38,14 @@ fn convert_aggregate_call(
     order_by: Vec<SortExpr>,
     s: &mut Scope,
 ) -> Result<SqlExpr, String> {
+    // A standalone aggregate with no argument, e.g. `%count`, which is shorthand for `count(*)`.
+    // Only `count` is meaningful without an argument.
+    if e.is_empty() {
+        if name == "count" {
+            return Ok(build::agg::count_star());
+        }
+        return Err(msg::aggregate_fn_without_argument(name));
+    }
     let func = s
         .get_aggregate_function(name)
         .ok_or_else(|| unknown_aggregate_function(name))?;
@@ -144,22 +154,36 @@ fn agg_1(
     let Expr::Path(path_parts) = arg0 else {
         return Err(msg::aggregate_fn_applied_to_a_non_path());
     };
-    let clarified_path = clarify_path(path_parts, scope)?;
-    let Some(ClarifiedPathTail::ChainToMany((chain_to_many, column_name_opt))) =
-        clarified_path.tail
-    else {
-        return Err(msg::aggregate_fn_applied_to_path_to_one());
-    };
-    let Some(column_name) = column_name_opt else {
-        return Err(msg::aggregate_fn_applied_to_a_path_without_a_column());
-    };
-    let aggregate_expr_template = AggregateExprTemplate::new(column_name, agg_wrapper, order_by);
-    scope.join_chain_to_many(
-        &clarified_path.head,
-        chain_to_many,
-        Some(aggregate_expr_template),
-        CtePurpose::AggregateValue,
-    )
+    let ClarifiedPath { head, tail } = clarify_path(path_parts, scope)?;
+    match tail {
+        // Aggregating data that joins many records (e.g. `#issues.created_at%max`). This is handled
+        // by building a CTE that performs the aggregation grouped by the linking column.
+        Some(ClarifiedPathTail::ChainToMany((chain_to_many, column_name_opt))) => {
+            let Some(column_name) = column_name_opt else {
+                return Err(msg::aggregate_fn_applied_to_a_path_without_a_column());
+            };
+            let aggregate_expr_template =
+                AggregateExprTemplate::new(column_name, agg_wrapper, order_by);
+            scope.join_chain_to_many(
+                &head,
+                chain_to_many,
+                Some(aggregate_expr_template),
+                CtePurpose::AggregateValue,
+            )
+        }
+        // Aggregating a column on the base table or a to-one related table (e.g. `created_at%max`).
+        // This produces a direct SQL aggregate expression used in conjunction with `GROUP BY`.
+        Some(ClarifiedPathTail::Column(column_name)) => {
+            let table_name = match head {
+                Some(chain_to_one) => scope.join_chain_to_one(&chain_to_one),
+                None => scope.get_base_table().name.clone(),
+            };
+            let reference = scope.table_column_expr(&table_name, &column_name);
+            let order_by_str = render_order_by(order_by, scope)?;
+            Ok(agg_wrapper(reference, order_by_str))
+        }
+        None => Err(msg::aggregate_fn_applied_to_a_path_without_a_column()),
+    }
 }
 
 pub fn get_standard_aggregate_functions() -> AggregateFuncMap {

--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -69,9 +69,11 @@ impl Compiler {
         let ConvertedResultColumns {
             columns,
             sorting: column_sorting,
+            grouping,
             column_annotations,
         } = convert_result_columns(result_columns, &mut scope)?;
         select.columns = columns;
+        select.grouping = grouping;
         // Standalone `\\` sorts take precedence over column `\s` sorts, hence they come first.
         select.sorting = standalone_sorting
             .into_iter()

--- a/compiler/src/compiler/paths/ctes.rs
+++ b/compiler/src/compiler/paths/ctes.rs
@@ -53,7 +53,7 @@ impl AggregateExprTemplate {
     }
 }
 
-fn render_order_by(order_by: Vec<SortExpr>, scope: &mut Scope) -> Result<String, String> {
+pub fn render_order_by(order_by: Vec<SortExpr>, scope: &mut Scope) -> Result<String, String> {
     if order_by.is_empty() {
         return Ok(String::new());
     }

--- a/compiler/src/compiler/result_columns.rs
+++ b/compiler/src/compiler/result_columns.rs
@@ -12,17 +12,60 @@ use crate::{
     },
 };
 
+use self::grouping::GroupingStack;
 use self::sorting::SortingStack;
 
 use super::{expr::convert_expr, scope::Scope};
 
-/// The result of converting result columns: the SQL columns, the sorting, and a `column_annotations`
-/// vector that is positionally aligned with `columns` (one entry per emitted column, `None` where
-/// the column has no annotation).
+/// The result of converting result columns: the SQL columns, the sorting, the grouping, and a
+/// `column_annotations` vector that is positionally aligned with `columns` (one entry per emitted
+/// column, `None` where the column has no annotation).
 pub struct ConvertedResultColumns {
     pub columns: Vec<Column>,
     pub sorting: Vec<SortEntry>,
+    pub grouping: Vec<SqlExpr>,
     pub column_annotations: Vec<Option<AnnotationValue>>,
+}
+
+/// Determines whether an expression contains an aggregate function (or otherwise aggregates data).
+/// Used to validate that, in a grouped query, every result column is either a grouping column or an
+/// aggregate. A path that references many records (e.g. `#issues`) aggregates by default, as does a
+/// "has quantity" expression (e.g. `++#issues`).
+fn contains_aggregate(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call(call) => {
+            matches!(call.dimension, FunctionDimension::Aggregate)
+                || call.args.iter().any(contains_aggregate)
+        }
+        Expr::Path(parts) => parts
+            .iter()
+            .any(|part| matches!(part, PathPart::TableWithMany(_))),
+        Expr::HasQuantity(_) => true,
+        Expr::Product(a, b) | Expr::Quotient(a, b) | Expr::Sum(a, b) | Expr::Difference(a, b) => {
+            contains_aggregate(a) || contains_aggregate(b)
+        }
+        Expr::Not(e) => contains_aggregate(e),
+        Expr::ConditionSet(cs) => cs.entries.iter().any(contains_aggregate),
+        Expr::Comparison(c) => {
+            comparison_side_contains_aggregate(&c.left)
+                || comparison_side_contains_aggregate(&c.right)
+        }
+        Expr::Number(_)
+        | Expr::Date(_)
+        | Expr::Duration(_)
+        | Expr::String(_)
+        | Expr::Variable(_) => false,
+    }
+}
+
+fn comparison_side_contains_aggregate(side: &ComparisonSide) -> bool {
+    match side {
+        ComparisonSide::Expr(e) => contains_aggregate(e),
+        ComparisonSide::Expansion(cs) => cs.entries.iter().any(contains_aggregate),
+        ComparisonSide::Range(r) => {
+            contains_aggregate(&r.lower.expr) || contains_aggregate(&r.upper.expr)
+        }
+    }
 }
 
 /// Converts standalone `\\` sorting expressions into SQL sort entries, preserving the order in
@@ -52,6 +95,10 @@ pub fn convert_result_columns(
     let mut columns = Vec::<Column>::new();
     let mut column_annotations = Vec::<Option<AnnotationValue>>::new();
     let mut sorting_stack = SortingStack::new();
+    let mut grouping_stack = GroupingStack::new();
+    // Whether the query emits a result column that is neither a grouping column nor an aggregate.
+    // Such a column is only valid when the query has no grouping at all.
+    let mut has_ungrouped_unaggregated = false;
     for column_statement in result_columns {
         match column_statement {
             ResultColumnStatement::Spec(spec) => {
@@ -60,6 +107,8 @@ pub fn convert_result_columns(
                     &mut columns,
                     &mut column_annotations,
                     &mut sorting_stack,
+                    &mut grouping_stack,
+                    &mut has_ungrouped_unaggregated,
                     scope,
                 )?;
             }
@@ -69,45 +118,71 @@ pub fn convert_result_columns(
                     &mut columns,
                     &mut column_annotations,
                     &mut sorting_stack,
+                    &mut grouping_stack,
+                    &mut has_ungrouped_unaggregated,
                     scope,
                 )?;
             }
         }
     }
+    let grouping: Vec<SqlExpr> = grouping_stack.into();
+    if !grouping.is_empty() && has_ungrouped_unaggregated {
+        return Err(msg::ungrouped_unaggregated_column());
+    }
     Ok(ConvertedResultColumns {
         columns,
         sorting: sorting_stack.into(),
+        grouping,
         column_annotations,
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_spec(
     spec: ColumnSpec,
     columns: &mut Vec<Column>,
     column_annotations: &mut Vec<Option<AnnotationValue>>,
     sorting_stack: &mut SortingStack,
+    grouping_stack: &mut GroupingStack,
+    has_ungrouped_unaggregated: &mut bool,
     scope: &mut Scope,
 ) -> Result<(), String> {
+    let ColumnControl {
+        sort,
+        group,
+        is_partition_by: _,
+        is_hidden: _,
+    } = spec.column_control;
+    let is_grouped = group.is_some();
+    let is_aggregated = contains_aggregate(&spec.expr);
     let expr = convert_expr(spec.expr, scope)?;
     let alias = spec.alias;
-    if let Some(sort_spec) = spec.column_control.sort {
+    if let Some(sort_spec) = sort {
         let sorting_expr = alias
             .as_ref()
             .map(|a| SqlExpr::atom(scope.options.dialect.quote_identifier(a)))
             .unwrap_or_else(|| expr.clone());
         sorting_stack.push(sorting_expr, sort_spec);
     }
+    if let Some(group_spec) = group {
+        grouping_stack.push(expr.clone(), group_spec);
+    }
+    if !is_grouped && !is_aggregated {
+        *has_ungrouped_unaggregated = true;
+    }
     columns.push(Column { expr, alias });
     column_annotations.push(spec.annotation);
-    // TODO convert GroupSpec into GROUP BY
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_glob(
     glob: ColumnGlob,
     columns: &mut Vec<Column>,
     column_annotations: &mut Vec<Option<AnnotationValue>>,
     sorting_stack: &mut SortingStack,
+    grouping_stack: &mut GroupingStack,
+    has_ungrouped_unaggregated: &mut bool,
     scope: &mut Scope,
 ) -> Result<(), String> {
     scope.with_path_prefix(glob.head.clone(), |scope| -> Result<(), String> {
@@ -116,7 +191,10 @@ fn handle_glob(
                 let sql_expr = convert_expr(spec.expr.clone(), scope)?;
                 sorting_stack.push(sql_expr, sort_spec.to_owned());
             }
-            // TODO convert GroupSpec into GROUP BY
+            if let Some(ref group_spec) = spec.column_control.group {
+                let sql_expr = convert_expr(spec.expr.clone(), scope)?;
+                grouping_stack.push(sql_expr, group_spec.to_owned());
+            }
         }
         Ok(())
     })?;
@@ -146,6 +224,7 @@ fn handle_glob(
     };
 
     let mut hidden_columns: HashSet<usize> = HashSet::new();
+    let mut grouped_columns: HashSet<usize> = HashSet::new();
     let mut column_aliases: HashMap<usize, String> = HashMap::new();
     let mut column_annotations_map: HashMap<usize, AnnotationValue> = HashMap::new();
 
@@ -159,6 +238,9 @@ fn handle_glob(
                     .ok_or_else(|| msg::col_not_in_table(column_name, &table.name))?;
                 if spec.column_control.is_hidden {
                     hidden_columns.insert(column_id);
+                }
+                if spec.column_control.group.is_some() {
+                    grouped_columns.insert(column_id);
                 }
                 if let Some(alias) = spec.alias {
                     column_aliases.insert(column_id, alias);
@@ -174,6 +256,11 @@ fn handle_glob(
         let expr = scope.table_column_expr(&table_alias, &column.name);
         let alias = column_aliases.get(&column.id).cloned();
         if !hidden_columns.contains(&column.id) {
+            // A glob emits raw table columns, which are not aggregates. In a grouped query each
+            // such column must therefore be one of the grouping columns.
+            if !grouped_columns.contains(&column.id) {
+                *has_ungrouped_unaggregated = true;
+            }
             columns.push(Column { expr, alias });
             column_annotations.push(column_annotations_map.get(&column.id).cloned());
         }
@@ -227,6 +314,54 @@ mod sorting {
             let max_ordinal = entries.iter().filter_map(|e| e.ordinal).max().unwrap_or(0);
             entries.sort_by_key(|entry| entry.ordinal.unwrap_or(max_ordinal.saturating_add(1)));
             entries.into_iter().map(|entry| entry.entry).collect()
+        }
+    }
+}
+
+mod grouping {
+    use querydown_parser::ast::GroupSpec;
+
+    use crate::sql::tree::SqlExpr;
+
+    struct UnplacedGroupEntry {
+        expr: SqlExpr,
+        ordinal: Option<u32>,
+    }
+
+    /// Collects the `GROUP BY` expressions, ordering them by their ordinals (`\g1`, `\g2`, …).
+    /// Entries without an explicit ordinal keep the order in which they appear, after all entries
+    /// that do specify an ordinal — mirroring [`super::sorting::SortingStack`].
+    pub struct GroupingStack {
+        entries: Vec<UnplacedGroupEntry>,
+    }
+
+    impl Default for GroupingStack {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl GroupingStack {
+        pub fn new() -> Self {
+            Self {
+                entries: Vec::new(),
+            }
+        }
+
+        pub fn push(&mut self, expr: SqlExpr, group_spec: GroupSpec) {
+            self.entries.push(UnplacedGroupEntry {
+                expr,
+                ordinal: group_spec.ordinal,
+            });
+        }
+    }
+
+    impl From<GroupingStack> for Vec<SqlExpr> {
+        fn from(stack: GroupingStack) -> Self {
+            let mut entries = stack.entries;
+            let max_ordinal = entries.iter().filter_map(|e| e.ordinal).max().unwrap_or(0);
+            entries.sort_by_key(|entry| entry.ordinal.unwrap_or(max_ordinal.saturating_add(1)));
+            entries.into_iter().map(|entry| entry.expr).collect()
         }
     }
 }

--- a/compiler/src/errors/msg.rs
+++ b/compiler/src/errors/msg.rs
@@ -33,8 +33,11 @@ pub fn path_to_many_with_column_name_and_no_agg_fn(column_name: &str) -> String 
     )
 }
 
-pub fn aggregate_fn_applied_to_path_to_one() -> String {
-    "Aggregate functions can only be applied to data that joins many records.".to_string()
+pub fn aggregate_fn_without_argument(function_name: &str) -> String {
+    format!(
+        "The aggregate function `{}` requires an argument. Only `count` may be used on its own.",
+        function_name
+    )
 }
 
 pub fn aggregate_fn_applied_to_a_non_path() -> String {
@@ -66,6 +69,10 @@ pub fn column_glob_after_non_fk_column(column_name: &str) -> String {
 /// TODO: we should improve the ClarifiedPath data structure to make this impossible
 pub fn empty_path() -> String {
     "Bug: Empty path.".to_string()
+}
+
+pub fn ungrouped_unaggregated_column() -> String {
+    "In a grouped query, every result column must either be a grouping column (marked with `\\g`) or contain an aggregate function.".to_string()
 }
 
 pub fn compare_two_ranges() -> String {

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -1203,6 +1203,118 @@ ORDER BY
   "issues"."title" ASC NULLS LAST;
 ```
 
+## Grouping and aggregation
+
+### Basic grouping
+
+> For each issue status, show the number of issues and the date of the most recently created issue
+
+```qd
+#issues $status \g $%count $created_at%max
+```
+
+```sql
+SELECT
+  "issues"."status",
+  count(*),
+  max("issues"."created_at")
+FROM "issues"
+GROUP BY "issues"."status";
+```
+
+### Grouping by multiple columns
+
+> Grouping ordinals (`\g1`, `\g2`) control the order of the `GROUP BY` columns, independent of the
+> order in which the columns appear in the result.
+
+```qd
+#issues $status \g2 $author \g1 $%count
+```
+
+```sql
+SELECT
+  "issues"."status",
+  "issues"."author",
+  count(*)
+FROM "issues"
+GROUP BY "issues"."author", "issues"."status";
+```
+
+### Grouping with an aliased aggregate
+
+> For each status, count the issues and show the earliest and latest creation dates.
+
+```qd
+#issues
+$status \g
+$%count -> total
+$created_at%min -> earliest
+$created_at%max -> latest
+```
+
+```sql
+SELECT
+  "issues"."status",
+  count(*) AS "total",
+  min("issues"."created_at") AS "earliest",
+  max("issues"."created_at") AS "latest"
+FROM "issues"
+GROUP BY "issues"."status";
+```
+
+### Grouping by a column on a related table
+
+> For each author, count their issues.
+
+```qd
+#issues $author.username \g $%count
+```
+
+```sql
+SELECT
+  "users"."username",
+  count(*)
+FROM "issues"
+LEFT JOIN "users" ON
+  "issues"."author" = "users"."id"
+GROUP BY "users"."username";
+```
+
+### Grouping combined with sorting
+
+> For each status, count the issues, showing the most populous statuses first.
+
+```qd
+#issues $status \g $%count \sd
+```
+
+```sql
+SELECT
+  "issues"."status",
+  count(*)
+FROM "issues"
+GROUP BY "issues"."status"
+ORDER BY
+  count(*) DESC NULLS LAST;
+```
+
+### Aggregating with sum and avg over base columns
+
+> For each status, show the sum and average of the issue ids.
+
+```qd
+#issues $status \g $id%sum $id%avg
+```
+
+```sql
+SELECT
+  "issues"."status",
+  sum("issues"."id"),
+  avg("issues"."id")
+FROM "issues"
+GROUP BY "issues"."status";
+```
+
 ## Column globs
 
 ### Basic column glob

--- a/compiler/src/tests/grouping.rs
+++ b/compiler/src/tests/grouping.rs
@@ -1,0 +1,65 @@
+//! Unit tests for grouping and aggregation that don't fit the SQL-string corpus, principally the
+//! validation rule that, in a grouped query, every result column must be a grouping column or an
+//! aggregate.
+
+use super::corpus_loader::build_options;
+use super::get_test_resource;
+use crate::Compiler;
+
+fn compile(input: &str) -> Result<String, String> {
+    let schema_json = get_test_resource("issue_schema.json");
+    let options = build_options(crate::options::IdentifierResolution::Flexible, "postgres");
+    let compiler = Compiler::new(&schema_json, options).unwrap();
+    compiler.compile(input.to_string()).map(|r| r.sql)
+}
+
+#[test]
+fn standalone_count_is_count_star() {
+    let sql = compile("#issues $status \\g $%count").unwrap();
+    assert!(sql.contains("count(*)"), "got: {sql}");
+    assert!(sql.contains("GROUP BY \"issues\".\"status\""), "got: {sql}");
+}
+
+#[test]
+fn ungrouped_unaggregated_column_is_rejected() {
+    // `title` is neither grouped nor aggregated, so the grouped query is invalid.
+    let err = compile("#issues $status \\g $title $%count").unwrap_err();
+    assert!(err.contains("grouping column"), "got: {err}");
+}
+
+#[test]
+fn grouping_column_need_not_be_aggregated() {
+    // The grouped column itself is exempt from the "must be aggregated" rule.
+    assert!(compile("#issues $status \\g $%count").is_ok());
+}
+
+#[test]
+fn multiple_grouping_columns_are_allowed() {
+    let sql = compile("#issues $status \\g $author \\g $%count").unwrap();
+    assert!(
+        sql.contains("GROUP BY \"issues\".\"status\", \"issues\".\"author\""),
+        "got: {sql}"
+    );
+}
+
+#[test]
+fn aggregate_without_grouping_aggregates_whole_table() {
+    // An aggregate with no grouping is valid SQL (it collapses the whole table to one row) and
+    // emits no GROUP BY clause.
+    let sql = compile("#issues $%count").unwrap();
+    assert!(sql.contains("count(*)"), "got: {sql}");
+    assert!(!sql.contains("GROUP BY"), "got: {sql}");
+}
+
+#[test]
+fn standalone_non_count_aggregate_is_rejected() {
+    // Only `count` is meaningful as a standalone aggregate; `%max` needs an argument.
+    let err = compile("#issues $status \\g $%max").unwrap_err();
+    assert!(err.contains("requires an argument"), "got: {err}");
+}
+
+#[test]
+fn ungrouped_query_with_naked_column_is_allowed() {
+    // Without any grouping, a plain column is fine.
+    assert!(compile("#issues $title").is_ok());
+}

--- a/compiler/src/tests/mod.rs
+++ b/compiler/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod corpus;
 mod corpus_loader;
 #[cfg(feature = "db-tests")]
 mod db_corpus;
+mod grouping;
 mod test_utils;
 
 pub use test_utils::get_test_resource;

--- a/docs/language.md
+++ b/docs/language.md
@@ -447,8 +447,6 @@ By default, `NULL` values are sorted last, but this behavior can be modified usi
 
 ### Grouping and aggregation
 
-_(🚧 Not yet implemented)_
-
 Grouping is indicated by the `g` flag, similar to sorting.
 
 > For each issue status, show the number of issues and the date of the most recently created issue
@@ -457,9 +455,11 @@ Grouping is indicated by the `g` flag, similar to sorting.
 #issues $status \g $%count $created_at%max
 ```
 
-- All ungrouped columns must contain an aggregate function
+- All ungrouped columns must contain an aggregate function. Otherwise the compiler reports an error.
 - `%count` can occur on its own (outside of a function pipeline), which is equivalent to `count(*)`.
-- Grouping by multiple columns is done via `\g1` and `\g2`, similar to sorting.
+- Aggregate functions like `%max`, `%sum`, and `%avg` may be applied to columns on the base table (e.g. `created_at%max`) or on a related table reachable via a single record (e.g. `author.created_at%max`).
+- Grouping by multiple columns is done via `\g1` and `\g2`, similar to sorting. Columns without an explicit ordinal are grouped in the order they appear, after all columns that do specify an ordinal.
+- Grouping and sorting can be combined, e.g. `#issues $status \g $%count \sd` to sort the groups by their counts.
 
 ### Column globs
 

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -507,6 +507,31 @@ mod tests {
             })))
         );
 
+        // A standalone aggregate `%count` has no `arg0`, so its `args` vector is empty. This is how
+        // `count(*)` is written.
+        assert_eq!(
+            p("%count"),
+            Ok(Expr::Call(Call {
+                name: "count".to_string(),
+                dimension: FunctionDimension::Aggregate,
+                syntax: CallSyntax::Piped,
+                args: vec![],
+                order_by: vec![],
+            }))
+        );
+
+        // A piped aggregate `created_at%max` carries the piped-in expression as its single argument.
+        assert_eq!(
+            p("created_at%max"),
+            Ok(Expr::Call(Call {
+                name: "max".to_string(),
+                dimension: FunctionDimension::Aggregate,
+                syntax: CallSyntax::Piped,
+                args: vec![Expr::Path(vec![PathPart::Column("created_at".to_string())])],
+                order_by: vec![],
+            }))
+        );
+
         // A `!` prefix negates a bare expression.
         assert_eq!(
             p("!foo"),

--- a/parser/src/parser/expr/pipe.rs
+++ b/parser/src/parser/expr/pipe.rs
@@ -20,6 +20,20 @@ fn agg_sort_expr<'src>(expr_parser: impl Psr<'src, Expr>) -> impl Psr<'src, Sort
         })
 }
 
+/// An aggregate's optional ORDER BY clause, e.g. the `(\name)` in `labels.name%list(\name)`. Built
+/// from a fresh copy of the extra-args expression parser at each use site because the parser is
+/// consumed when constructed.
+fn aggregate_order_by<'src>(args_expr: impl Psr<'src, Expr>) -> impl Psr<'src, Vec<SortExpr>> {
+    just(COMPOSITION_ARGUMENT_BRACE_L)
+        .ignore_then(
+            agg_sort_expr(args_expr)
+                .padded_by(pad())
+                .repeated()
+                .collect::<Vec<SortExpr>>(),
+        )
+        .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R))
+}
+
 pub fn pipe<'src>(
     arg0_expr: impl Psr<'src, Expr>,
     extra_args_expr: impl Psr<'src, Expr>,
@@ -31,15 +45,6 @@ pub fn pipe<'src>(
                 .padded_by(pad())
                 .repeated()
                 .collect::<Vec<Expr>>(),
-        )
-        .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R));
-
-    let aggregate_order_by = just(COMPOSITION_ARGUMENT_BRACE_L)
-        .ignore_then(
-            agg_sort_expr(extra_args_expr)
-                .padded_by(pad())
-                .repeated()
-                .collect::<Vec<SortExpr>>(),
         )
         .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R));
 
@@ -59,7 +64,7 @@ pub fn pipe<'src>(
     let aggregate_call = just(COMPOSITION_PIPE_AGGREGATE)
         .padded_by(pad())
         .ignore_then(ident())
-        .then(aggregate_order_by.or_not())
+        .then(aggregate_order_by(extra_args_expr.clone()).or_not())
         .map(|(name, order_by)| {
             (
                 FunctionDimension::Aggregate,
@@ -69,7 +74,24 @@ pub fn pipe<'src>(
             )
         });
 
-    arg0_expr.foldl(
+    // A standalone (leading) aggregate, e.g. `%count`, which has no `arg0` to its left. This is how
+    // `count(*)` is written. It produces a [`Call`] with an empty `args` vector, distinguishing it
+    // from a piped aggregate like `created_at%max` whose `args` contains the piped-in expression.
+    let leading_aggregate = just(COMPOSITION_PIPE_AGGREGATE)
+        .padded_by(pad())
+        .ignore_then(ident())
+        .then(aggregate_order_by(extra_args_expr).or_not())
+        .map(|(name, order_by)| {
+            Expr::Call(Call {
+                name: name.to_string(),
+                dimension: FunctionDimension::Aggregate,
+                syntax: CallSyntax::Piped,
+                args: vec![],
+                order_by: order_by.unwrap_or_default(),
+            })
+        });
+
+    choice((leading_aggregate, arg0_expr)).foldl(
         choice((scalar_call, aggregate_call)).repeated(),
         |arg0, (dimension, name, extra_args, order_by)| {
             let args = std::iter::once(arg0).chain(extra_args).collect();


### PR DESCRIPTION
## Summary

Implements the grouping and aggregation feature described in the [language guide](../blob/main/docs/language.md#grouping-and-aggregation), and marks it as implemented in the docs.

Querydown can now group result rows with the `\g` column-control flag and aggregate the other columns with `%` aggregate functions over the base table:

```qd
#issues $status \g $%count $created_at%max
```

```sql
SELECT
  "issues"."status",
  count(*),
  max("issues"."created_at")
FROM "issues"
GROUP BY "issues"."status";
```

## What changed

- **Parser**: a standalone `%count` (with no left-hand argument) now parses as `count(*)`. A leading aggregate produces a `Call` with an empty `args` vector, distinguishing it from a piped aggregate like `created_at%max`.
- **Aggregates over base/to-one columns**: aggregate functions (`%max`, `%min`, `%sum`, `%avg`, …) can now be applied directly to base-table columns (e.g. `created_at%max`) and to columns on singly-related tables (e.g. `author.created_at%max`), producing direct SQL aggregate expressions. Previously aggregates only worked over to-many relationships via CTEs — that path is unchanged.
- **`GROUP BY`**: built from `\g` flags, honoring ordinals (`\g1`, `\g2`) exactly like sorting does (explicit ordinals first, then appearance order).
- **Validation**: in a grouped query, every result column must be either a grouping column or contain an aggregate; otherwise the compiler returns a clear error.
- **Docs**: the "Grouping and aggregation" section is no longer marked 🚧, with expanded notes.

## Tests

- Parser unit tests for standalone `%count` and piped `created_at%max`.
- Corpus cases (also exercised against real Postgres & DuckDB under `--features db-tests`): basic grouping, multiple grouping columns with ordinals, aliased aggregates, grouping by a related-table column, grouping combined with sorting, and `sum`/`avg` over base columns.
- Compiler tests for the validation rule (rejecting ungrouped/unaggregated columns, rejecting a standalone non-`count` aggregate) and for valid edge cases (aggregate without grouping collapses the whole table; ungrouped plain columns remain fine).

`cargo check`, `cargo clippy`, `cargo build`, and `cargo test` all pass. The DB-backed corpus tests (`--features db-tests`) compile cleanly; they were not executed here because the `postgres`/`duckdb` binaries aren't available in this environment (the dev container provides them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1G9wtyUZAoLYh95ip5Mor)_