### PR TITLE
Implement user-defined constants, functions, and custom comparisons

### DIFF
--- a/compiler/src/compiler/comparisons.rs
+++ b/compiler/src/compiler/comparisons.rs
@@ -1,7 +1,7 @@
 use querydown_parser::ast::*;
 
 use crate::{
-    compiler::expr::convert_expr,
+    compiler::expr::{convert_expr, convert_expr_with_path_prefix},
     errors::msg,
     schema::ValueType,
     sql::{
@@ -18,6 +18,22 @@ use super::{
 
 pub fn convert_comparison(c: Comparison, scope: &mut Scope) -> Result<SqlExpr, String> {
     use ComparisonSide::{Expansion as CmpExpansion, Expr as CmpExpr, Range as CmpRange};
+
+    // A custom comparison is invoked when the left-hand side is a path naming a registered custom
+    // comparison. When one matches, its body is expanded in place of the whole comparison.
+    if scope.has_custom_comparisons() {
+        if let ComparisonSide::Expr(Expr::Path(parts)) = &c.left {
+            let prefixed: Vec<PathPart> = scope
+                .path_prefix
+                .iter()
+                .cloned()
+                .chain(parts.iter().cloned())
+                .collect();
+            if let Some((head_parts, def)) = resolve_custom_comparison(&prefixed, scope)? {
+                return convert_custom_comparison(def, head_parts, c.operator, c.right, scope);
+            }
+        }
+    }
 
     let mut simple = |l: &Expr, r: &Expr| convert_simple_comparison(l, c.operator, r, scope);
 
@@ -262,5 +278,223 @@ fn convert_expression_vs_zero(
     match cmp {
         ComparisonVsZero::Eq => Ok(cmp::is_null(pk)),
         ComparisonVsZero::Gt => Ok(cmp::is_not_null(pk)),
+    }
+}
+
+/// If `parts` names a custom comparison, returns the head of the path (the parts leading to the
+/// table hosting the comparison) together with the matched definition. A real column of the same
+/// name takes precedence, in which case this returns `None`.
+fn resolve_custom_comparison(
+    parts: &[PathPart],
+    scope: &Scope,
+) -> Result<Option<(Vec<PathPart>, CustomComparisonDef)>, String> {
+    // Only a trailing plain column can name a custom comparison.
+    let Some((PathPart::Column(name), head_parts)) = parts.split_last() else {
+        return Ok(None);
+    };
+    // Determine the table hosting the comparison. Only the base table (empty head) or a single
+    // related record reachable via the head can host one.
+    let table = if head_parts.is_empty() {
+        scope.get_base_table()
+    } else {
+        let clarified = clarify_path(head_parts.to_vec(), scope)?;
+        match (clarified.head, clarified.tail) {
+            (Some(chain_to_one), None) => scope
+                .schema
+                .tables
+                .get(&chain_to_one.get_ending_table_id())
+                .unwrap(),
+            _ => return Ok(None),
+        }
+    };
+    // A real column of the same name takes precedence over a custom comparison.
+    if scope
+        .options
+        .resolve_identifier(&table.column_lookup, name)
+        .is_some()
+    {
+        return Ok(None);
+    }
+    Ok(scope
+        .get_custom_comparison(&table.name, name)
+        .map(|def| (head_parts.to_vec(), def.clone())))
+}
+
+/// Expands a custom comparison: the right-hand side value is bound to the definition's parameter and
+/// the (possibly operator-switched) body is compiled in place of the comparison.
+fn convert_custom_comparison(
+    def: CustomComparisonDef,
+    head_parts: Vec<PathPart>,
+    call_operator: Operator,
+    right: ComparisonSide,
+    scope: &mut Scope,
+) -> Result<SqlExpr, String> {
+    let body = switched_body(&def, call_operator)?;
+    match right {
+        ComparisonSide::Expr(value) => {
+            convert_custom_comparison_body(&def.param, value, body, &head_parts, scope)
+        }
+        // An expansion on the right binds the parameter to each entry in turn, combining the
+        // results with the expansion's conjunction (e.g. `comment:..["a" "b"]`).
+        ComparisonSide::Expansion(conditions) => {
+            let exprs = conditions
+                .entries
+                .into_iter()
+                .map(|value| {
+                    convert_custom_comparison_body(
+                        &def.param,
+                        value,
+                        body.clone(),
+                        &head_parts,
+                        scope,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(cmp::condition_set(exprs, &conditions.conjunction))
+        }
+        ComparisonSide::Range(_) => Err(msg::custom_comparison_with_range(&def.name)),
+    }
+}
+
+fn convert_custom_comparison_body(
+    param: &str,
+    value: Expr,
+    body: Expr,
+    head_parts: &[PathPart],
+    scope: &mut Scope,
+) -> Result<SqlExpr, String> {
+    let bindings = vec![(param.to_string(), value)];
+    scope.with_variable_bindings(bindings, |scope| {
+        convert_expr_with_path_prefix(body, head_parts.to_vec(), scope)
+    })
+}
+
+/// Returns the custom comparison's body, with its `:` (match) operators rewritten to `call_operator`
+/// if the comparison is being called with a different operator than it was defined with. Operator
+/// switching is only permitted when the definition uses `:` and every comparison in the body also
+/// uses `:`.
+fn switched_body(def: &CustomComparisonDef, call_operator: Operator) -> Result<Expr, String> {
+    if call_operator == def.operator {
+        return Ok(def.body.clone());
+    }
+    if def.operator == Operator::Match && expr_all_match(&def.body) {
+        let mut body = def.body.clone();
+        rewrite_match_operator(&mut body, call_operator);
+        return Ok(body);
+    }
+    Err(msg::custom_comparison_operator_mismatch(&def.name))
+}
+
+/// Whether every comparison anywhere within `expr` uses the match (`:`) operator.
+fn expr_all_match(expr: &Expr) -> bool {
+    match expr {
+        Expr::Comparison(c) => {
+            matches!(c.operator, Operator::Match)
+                && side_all_match(&c.left)
+                && side_all_match(&c.right)
+        }
+        Expr::Not(e) => expr_all_match(e),
+        Expr::Product(a, b) | Expr::Quotient(a, b) | Expr::Sum(a, b) | Expr::Difference(a, b) => {
+            expr_all_match(a) && expr_all_match(b)
+        }
+        Expr::ConditionSet(cs) => cs.entries.iter().all(expr_all_match),
+        Expr::HasQuantity(h) => h.path_parts.iter().all(pathpart_all_match),
+        Expr::Case(c) => {
+            c.variants
+                .iter()
+                .all(|v| expr_all_match(&v.condition) && expr_all_match(&v.value))
+                && expr_all_match(&c.fallback)
+        }
+        Expr::Call(c) => c.args.iter().all(expr_all_match),
+        Expr::Path(parts) => parts.iter().all(pathpart_all_match),
+        Expr::Number(_)
+        | Expr::Date(_)
+        | Expr::Duration(_)
+        | Expr::String(_)
+        | Expr::Variable(_) => true,
+    }
+}
+
+fn side_all_match(side: &ComparisonSide) -> bool {
+    match side {
+        ComparisonSide::Expr(e) => expr_all_match(e),
+        ComparisonSide::Expansion(cs) => cs.entries.iter().all(expr_all_match),
+        ComparisonSide::Range(r) => expr_all_match(&r.lower.expr) && expr_all_match(&r.upper.expr),
+    }
+}
+
+fn pathpart_all_match(part: &PathPart) -> bool {
+    match part {
+        PathPart::TableWithMany(t) => t.condition_set.entries.iter().all(expr_all_match),
+        PathPart::Column(_) | PathPart::TableWithOne(_) => true,
+    }
+}
+
+/// Rewrites every match (`:`) operator within `expr` to `new_operator`, recursing through the same
+/// structure that [`expr_all_match`] inspects.
+fn rewrite_match_operator(expr: &mut Expr, new_operator: Operator) {
+    match expr {
+        Expr::Comparison(c) => {
+            if matches!(c.operator, Operator::Match) {
+                c.operator = new_operator;
+            }
+            rewrite_side(&mut c.left, new_operator);
+            rewrite_side(&mut c.right, new_operator);
+        }
+        Expr::Not(e) => rewrite_match_operator(e, new_operator),
+        Expr::Product(a, b) | Expr::Quotient(a, b) | Expr::Sum(a, b) | Expr::Difference(a, b) => {
+            rewrite_match_operator(a, new_operator);
+            rewrite_match_operator(b, new_operator);
+        }
+        Expr::ConditionSet(cs) => cs
+            .entries
+            .iter_mut()
+            .for_each(|e| rewrite_match_operator(e, new_operator)),
+        Expr::HasQuantity(h) => h
+            .path_parts
+            .iter_mut()
+            .for_each(|p| rewrite_pathpart(p, new_operator)),
+        Expr::Case(c) => {
+            for v in c.variants.iter_mut() {
+                rewrite_match_operator(&mut v.condition, new_operator);
+                rewrite_match_operator(&mut v.value, new_operator);
+            }
+            rewrite_match_operator(&mut c.fallback, new_operator);
+        }
+        Expr::Call(c) => c
+            .args
+            .iter_mut()
+            .for_each(|e| rewrite_match_operator(e, new_operator)),
+        Expr::Path(parts) => parts
+            .iter_mut()
+            .for_each(|p| rewrite_pathpart(p, new_operator)),
+        Expr::Number(_)
+        | Expr::Date(_)
+        | Expr::Duration(_)
+        | Expr::String(_)
+        | Expr::Variable(_) => {}
+    }
+}
+
+fn rewrite_side(side: &mut ComparisonSide, new_operator: Operator) {
+    match side {
+        ComparisonSide::Expr(e) => rewrite_match_operator(e, new_operator),
+        ComparisonSide::Expansion(cs) => cs
+            .entries
+            .iter_mut()
+            .for_each(|e| rewrite_match_operator(e, new_operator)),
+        ComparisonSide::Range(r) => {
+            rewrite_match_operator(&mut r.lower.expr, new_operator);
+            rewrite_match_operator(&mut r.upper.expr, new_operator);
+        }
+    }
+}
+
+fn rewrite_pathpart(part: &mut PathPart, new_operator: Operator) {
+    if let PathPart::TableWithMany(t) = part {
+        t.condition_set
+            .entries
+            .iter_mut()
+            .for_each(|e| rewrite_match_operator(e, new_operator));
     }
 }

--- a/compiler/src/compiler/expr.rs
+++ b/compiler/src/compiler/expr.rs
@@ -49,15 +49,20 @@ pub fn convert_expr(expr: Expr, scope: &mut Scope) -> Result<SqlExpr, String> {
     }
 }
 
-fn convert_variable(variable: &str, _: &Scope) -> Result<SqlExpr, String> {
+fn convert_variable(variable: &str, scope: &mut Scope) -> Result<SqlExpr, String> {
     let sql = match variable {
         VAR_NOW => func::now(),
         VAR_INFINITY => value::infinity(),
         VAR_TRUE => value::true_(),
         VAR_FALSE => value::false_(),
         VAR_NULL => value::null(),
-        // TODO handle user-defined variables from scope
-        name => return Err(msg::unknown_variable(name)),
+        // A user-defined variable (constant or function parameter): inline its bound expression.
+        name => {
+            return match scope.get_variable(name) {
+                Some(expr) => convert_expr(expr.clone(), scope),
+                None => Err(msg::unknown_variable(name)),
+            }
+        }
     };
     Ok(SqlExpr::atom(sql.to_string()))
 }

--- a/compiler/src/compiler/expr.rs
+++ b/compiler/src/compiler/expr.rs
@@ -145,7 +145,7 @@ fn resolve_computed_column(
 
 /// Converts an expression with `path_prefix` temporarily set, restoring the previous prefix
 /// afterward (which, unlike [`Scope::with_path_prefix`], supports nesting).
-fn convert_expr_with_path_prefix(
+pub(super) fn convert_expr_with_path_prefix(
     expr: Expr,
     path_prefix: Vec<PathPart>,
     scope: &mut Scope,

--- a/compiler/src/compiler/functions.rs
+++ b/compiler/src/compiler/functions.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use querydown_parser::ast::{Call, Expr, FunctionDimension, SortExpr};
+use querydown_parser::ast::{Call, Expr, FunctionDef, FunctionDimension, SortExpr};
 
 use crate::{
     compiler::{
@@ -27,10 +27,40 @@ pub fn convert_call(call: Call, scope: &mut Scope) -> Result<SqlExpr, String> {
 }
 
 fn convert_scalar_call(name: &str, e: Vec<Expr>, s: &mut Scope) -> Result<SqlExpr, String> {
-    let func = s
-        .get_scalar_function(name)
-        .ok_or_else(|| unknown_scalar_function(name))?;
-    func(e, s)
+    // Built-in scalar functions take precedence; a user-defined function of the same name is only
+    // consulted if no built-in matches.
+    if let Some(func) = s.get_scalar_function(name) {
+        return func(e, s);
+    }
+    if let Some(def) = s.get_user_function(name).cloned() {
+        return convert_user_function_call(def, e, s);
+    }
+    Err(unknown_scalar_function(name))
+}
+
+/// Applies a user-defined scalar function by binding its parameters to the call's arguments and its
+/// local assignments, then compiling its body expression. Because the bindings map names to AST
+/// expressions (resolved lazily when referenced), the body is effectively inlined into the
+/// surrounding SQL.
+fn convert_user_function_call(
+    def: FunctionDef,
+    args: Vec<Expr>,
+    scope: &mut Scope,
+) -> Result<SqlExpr, String> {
+    if args.len() != def.params.len() {
+        return Err(msg::function_wrong_arg_count(
+            &def.name,
+            def.params.len(),
+            args.len(),
+        ));
+    }
+    let bindings: Vec<(String, Expr)> = def
+        .params
+        .into_iter()
+        .zip(args)
+        .chain(def.body.assignments.into_iter().map(|a| (a.name, a.expr)))
+        .collect();
+    scope.with_variable_bindings(bindings, |scope| convert_expr(def.body.expr, scope))
 }
 
 fn convert_aggregate_call(

--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -52,6 +52,7 @@ impl Compiler {
     pub fn compile(&self, input: String) -> Result<CompileResult, String> {
         let query = parse(&input)?;
         let mut scope = Scope::build(&self.options, &self.schema, &query.base_table)?;
+        scope.register_constants(query.constants);
         scope.register_computed_columns(query.computed_columns)?;
         let mut select = Select::from(scope.get_base_table().name.clone());
 

--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -53,6 +53,7 @@ impl Compiler {
         let query = parse(&input)?;
         let mut scope = Scope::build(&self.options, &self.schema, &query.base_table)?;
         scope.register_constants(query.constants);
+        scope.register_functions(query.functions);
         scope.register_computed_columns(query.computed_columns)?;
         let mut select = Select::from(scope.get_base_table().name.clone());
 

--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -54,6 +54,7 @@ impl Compiler {
         let mut scope = Scope::build(&self.options, &self.schema, &query.base_table)?;
         scope.register_constants(query.constants);
         scope.register_functions(query.functions);
+        scope.register_custom_comparisons(query.custom_comparisons)?;
         scope.register_computed_columns(query.computed_columns)?;
         let mut select = Select::from(scope.get_base_table().name.clone());
 

--- a/compiler/src/compiler/scope.rs
+++ b/compiler/src/compiler/scope.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use querydown_parser::ast::{ComputedColumn, ConstantDef, Expr, FunctionDef, PathPart};
+use querydown_parser::ast::{
+    ComputedColumn, ConstantDef, CustomComparisonDef, Expr, FunctionDef, PathPart,
+};
 
 use crate::{
     errors::msg,
@@ -44,6 +46,9 @@ pub struct Scope<'a, 'b> {
     variables: HashMap<String, Expr>,
     /// User-defined scalar functions, keyed by name, registered before the query.
     user_functions: HashMap<String, FunctionDef>,
+    /// Custom comparisons, defined before the query and keyed by `(canonical table name, comparison
+    /// name as written in the definition)`. The name is looked up using identifier resolution.
+    custom_comparisons: HashMap<String, HashMap<String, CustomComparisonDef>>,
 }
 
 impl<'a, 'b> Scope<'a, 'b> {
@@ -68,6 +73,7 @@ impl<'a, 'b> Scope<'a, 'b> {
             computed_columns: HashMap::new(),
             variables: HashMap::new(),
             user_functions: HashMap::new(),
+            custom_comparisons: HashMap::new(),
         })
     }
 
@@ -161,6 +167,50 @@ impl<'a, 'b> Scope<'a, 'b> {
             })
     }
 
+    /// Records the query's custom comparison definitions, validating that each refers to a real
+    /// table. The bodies are resolved lazily (when the comparison is used), so this does not
+    /// validate them and definition order does not matter.
+    pub fn register_custom_comparisons(
+        &mut self,
+        custom_comparisons: Vec<CustomComparisonDef>,
+    ) -> Result<(), String> {
+        for def in custom_comparisons {
+            let table = get_table_by_name(self.options, self.schema, &def.table)
+                .ok_or_else(|| msg::custom_comparison_unknown_table(&def.table))?;
+            self.custom_comparisons
+                .entry(table.name.clone())
+                .or_default()
+                .insert(def.name.clone(), def);
+        }
+        Ok(())
+    }
+
+    /// Whether any custom comparisons are registered (here or in a parent scope). Used to avoid the
+    /// cost of custom-comparison resolution on queries that define none.
+    pub fn has_custom_comparisons(&self) -> bool {
+        !self.custom_comparisons.is_empty()
+            || self
+                .parent
+                .map(|parent| parent.has_custom_comparisons())
+                .unwrap_or(false)
+    }
+
+    /// Looks up a custom comparison by table and name, using identifier resolution for the name.
+    /// Falls back to parent scopes.
+    pub fn get_custom_comparison(
+        &self,
+        table_name: &str,
+        name: &str,
+    ) -> Option<&CustomComparisonDef> {
+        self.custom_comparisons
+            .get(table_name)
+            .and_then(|comparisons| self.options.resolve_identifier(comparisons, name))
+            .or_else(|| {
+                self.parent
+                    .and_then(|parent| parent.get_custom_comparison(table_name, name))
+            })
+    }
+
     pub fn get_base_table(&self) -> &Table {
         self.base_table
     }
@@ -188,6 +238,7 @@ impl<'a, 'b> Scope<'a, 'b> {
             computed_columns: HashMap::new(),
             variables: HashMap::new(),
             user_functions: HashMap::new(),
+            custom_comparisons: HashMap::new(),
         }
     }
 

--- a/compiler/src/compiler/scope.rs
+++ b/compiler/src/compiler/scope.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use querydown_parser::ast::{ComputedColumn, ConstantDef, Expr, PathPart};
+use querydown_parser::ast::{ComputedColumn, ConstantDef, Expr, FunctionDef, PathPart};
 
 use crate::{
     errors::msg,
@@ -38,9 +38,12 @@ pub struct Scope<'a, 'b> {
     /// as written in the definition)`. The column name is looked up using identifier resolution.
     computed_columns: HashMap<String, HashMap<String, Expr>>,
     /// Variable bindings keyed by name (without the `@` sigil). This holds user-defined constants
-    /// (registered before the query). Each binding maps to an AST expression which is inlined
-    /// wherever the variable is referenced.
+    /// (registered before the query) as well as function parameters and local assignments (bound
+    /// temporarily while a user-defined function is being applied). Each binding maps to an AST
+    /// expression which is inlined wherever the variable is referenced.
     variables: HashMap<String, Expr>,
+    /// User-defined scalar functions, keyed by name, registered before the query.
+    user_functions: HashMap<String, FunctionDef>,
 }
 
 impl<'a, 'b> Scope<'a, 'b> {
@@ -64,6 +67,7 @@ impl<'a, 'b> Scope<'a, 'b> {
             aggregate_functions: get_standard_aggregate_functions(),
             computed_columns: HashMap::new(),
             variables: HashMap::new(),
+            user_functions: HashMap::new(),
         })
     }
 
@@ -81,6 +85,50 @@ impl<'a, 'b> Scope<'a, 'b> {
         self.variables
             .get(name)
             .or_else(|| self.parent.and_then(|parent| parent.get_variable(name)))
+    }
+
+    /// Records the query's user-defined function definitions. Their bodies are resolved lazily (when
+    /// the function is applied), so this does not validate them and definition order does not matter.
+    pub fn register_functions(&mut self, functions: Vec<FunctionDef>) {
+        for function in functions {
+            self.user_functions.insert(function.name.clone(), function);
+        }
+    }
+
+    /// Looks up a user-defined scalar function by name, falling back to parent scopes.
+    pub fn get_user_function(&self, name: &str) -> Option<&FunctionDef> {
+        self.user_functions.get(name).or_else(|| {
+            self.parent
+                .and_then(|parent| parent.get_user_function(name))
+        })
+    }
+
+    /// Evaluates `f` with additional variable bindings temporarily in scope, restoring the previous
+    /// bindings afterward. Used to bind a user-defined function's parameters and local assignments
+    /// while its body is being compiled.
+    pub fn with_variable_bindings<T>(
+        &mut self,
+        bindings: Vec<(String, Expr)>,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let mut saved: Vec<(String, Option<Expr>)> = Vec::with_capacity(bindings.len());
+        for (name, expr) in bindings {
+            let previous = self.variables.insert(name.clone(), expr);
+            saved.push((name, previous));
+        }
+        let result = f(self);
+        // Restore in reverse so that duplicate names are returned to their original state.
+        for (name, previous) in saved.into_iter().rev() {
+            match previous {
+                Some(expr) => {
+                    self.variables.insert(name, expr);
+                }
+                None => {
+                    self.variables.remove(&name);
+                }
+            }
+        }
+        result
     }
 
     /// Records the query's computed column definitions, validating that each refers to a real table.
@@ -139,6 +187,7 @@ impl<'a, 'b> Scope<'a, 'b> {
             aggregate_functions: HashMap::new(),
             computed_columns: HashMap::new(),
             variables: HashMap::new(),
+            user_functions: HashMap::new(),
         }
     }
 

--- a/compiler/src/compiler/scope.rs
+++ b/compiler/src/compiler/scope.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use querydown_parser::ast::{ComputedColumn, Expr, PathPart};
+use querydown_parser::ast::{ComputedColumn, ConstantDef, Expr, PathPart};
 
 use crate::{
     errors::msg,
@@ -37,6 +37,10 @@ pub struct Scope<'a, 'b> {
     /// Computed columns, defined before the query and keyed by `(canonical table name, column name
     /// as written in the definition)`. The column name is looked up using identifier resolution.
     computed_columns: HashMap<String, HashMap<String, Expr>>,
+    /// Variable bindings keyed by name (without the `@` sigil). This holds user-defined constants
+    /// (registered before the query). Each binding maps to an AST expression which is inlined
+    /// wherever the variable is referenced.
+    variables: HashMap<String, Expr>,
 }
 
 impl<'a, 'b> Scope<'a, 'b> {
@@ -59,7 +63,24 @@ impl<'a, 'b> Scope<'a, 'b> {
             scalar_functions: get_standard_scalar_functions(),
             aggregate_functions: get_standard_aggregate_functions(),
             computed_columns: HashMap::new(),
+            variables: HashMap::new(),
         })
+    }
+
+    /// Records the query's constant definitions. Like computed columns, the definitions' expressions
+    /// are resolved lazily (inlined when referenced), so this does not validate them and definition
+    /// order does not matter.
+    pub fn register_constants(&mut self, constants: Vec<ConstantDef>) {
+        for constant in constants {
+            self.variables.insert(constant.name, constant.expr);
+        }
+    }
+
+    /// Looks up a variable binding by name (without the `@` sigil), falling back to parent scopes.
+    pub fn get_variable(&self, name: &str) -> Option<&Expr> {
+        self.variables
+            .get(name)
+            .or_else(|| self.parent.and_then(|parent| parent.get_variable(name)))
     }
 
     /// Records the query's computed column definitions, validating that each refers to a real table.
@@ -117,6 +138,7 @@ impl<'a, 'b> Scope<'a, 'b> {
             scalar_functions: HashMap::new(),
             aggregate_functions: HashMap::new(),
             computed_columns: HashMap::new(),
+            variables: HashMap::new(),
         }
     }
 

--- a/compiler/src/errors/msg.rs
+++ b/compiler/src/errors/msg.rs
@@ -90,3 +90,19 @@ pub fn computed_column_unknown_table(table_name: &str) -> String {
 pub fn function_wrong_arg_count(function_name: &str, expected: usize, actual: usize) -> String {
     format!("The function `{function_name}` expects {expected} argument(s) but received {actual}.")
 }
+
+pub fn custom_comparison_unknown_table(table_name: &str) -> String {
+    format!("Custom comparison refers to unknown table `{table_name}`.")
+}
+
+pub fn custom_comparison_operator_mismatch(name: &str) -> String {
+    format!(
+        "The custom comparison `{name}` cannot be called with this operator. The operator may only \
+         be switched when the comparison is defined with `:` and every comparison in its body also \
+         uses `:`."
+    )
+}
+
+pub fn custom_comparison_with_range(name: &str) -> String {
+    format!("The custom comparison `{name}` cannot be used with a range.")
+}

--- a/compiler/src/errors/msg.rs
+++ b/compiler/src/errors/msg.rs
@@ -86,3 +86,7 @@ pub fn compare_range_without_eq() -> String {
 pub fn computed_column_unknown_table(table_name: &str) -> String {
     format!("Computed column refers to unknown table `{table_name}`.")
 }
+
+pub fn function_wrong_arg_count(function_name: &str, expected: usize, actual: usize) -> String {
+    format!("The function `{function_name}` expects {expected} argument(s) but received {actual}.")
+}

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -1942,3 +1942,146 @@ FROM "users"
 WHERE
   FLOOR(EXTRACT(epoch FROM NOW() - "users"."birth_date") / 31557600) >= 21;
 ```
+
+## Custom comparisons
+
+### Basic custom comparison
+
+> Find issues that have a comment containing the word "workaround". The `comment` custom comparison
+> is defined before the base table; using it expands its body in place.
+
+```qd
+#issues.comment:@x = ++#comments{body:@x}
+#issues comment:workaround $title
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "comments"."issue" AS "pk"
+    FROM "comments"
+    WHERE
+      COALESCE(strpos(lower("comments"."body" COLLATE "C"), lower('workaround' COLLATE "C")) > 0, FALSE)
+    GROUP BY "comments"."issue"
+  )
+SELECT
+  "issues"."title"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk"
+WHERE
+  "cte0"."pk" IS NOT NULL;
+```
+
+### Custom comparison called with a switched operator (regex)
+
+> When a custom comparison is defined with `:` and every comparison in its body also uses `:`, it
+> may be called with a different operator, which is substituted throughout the body. Here the regex
+> match operator is used.
+
+```qd
+#issues.comment:@x = ++#comments{body:@x}
+#issues comment:~"work[ -]?around" $title
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "comments"."issue" AS "pk"
+    FROM "comments"
+    WHERE
+      "comments"."body" ~* 'work[ -]?around'
+    GROUP BY "comments"."issue"
+  )
+SELECT
+  "issues"."title"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk"
+WHERE
+  "cte0"."pk" IS NOT NULL;
+```
+
+### Custom comparison called with a switched operator (exact equality)
+
+> The match operator can likewise be switched to exact equality.
+
+```qd
+#issues.comment:@x = ++#comments{body:@x}
+#issues comment:="+1" $title
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "comments"."issue" AS "pk"
+    FROM "comments"
+    WHERE
+      "comments"."body" = '+1'
+    GROUP BY "comments"."issue"
+  )
+SELECT
+  "issues"."title"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk"
+WHERE
+  "cte0"."pk" IS NOT NULL;
+```
+
+### Custom comparison with a multi-part body
+
+> A custom comparison's body can be any expression. Here `participant` checks whether a given
+> username has commented on, been assigned to, or authored an issue. Because the body contains
+> comparisons other than `:`, it must always be called exactly as defined (with `:`).
+
+```qd
+#issues.participant:@x = [
+  ++#comments{user.username:=@x}
+  ++#assignments{user.username:=@x}
+  author.username:=@x
+]
+#issues participant:david $title
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "comments"."issue" AS "pk"
+    FROM "comments"
+    LEFT JOIN "users" ON
+      "comments"."user" = "users"."id"
+    WHERE
+      "users"."username" = 'david'
+    GROUP BY "comments"."issue"
+  ),
+  "cte1" AS (
+    SELECT
+      "assignments"."issue" AS "pk"
+    FROM "assignments"
+    LEFT JOIN "users" ON
+      "assignments"."user" = "users"."id"
+    WHERE
+      "users"."username" = 'david'
+    GROUP BY "assignments"."issue"
+  )
+SELECT
+  "issues"."title"
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk"
+LEFT JOIN "cte1" ON
+  "issues"."id" = "cte1"."pk"
+LEFT JOIN "users" ON
+  "issues"."author" = "users"."id"
+WHERE
+  (
+    "cte0"."pk" IS NOT NULL
+    OR "cte1"."pk" IS NOT NULL
+    OR "users"."username" = 'david'
+  );
+```

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -1817,3 +1817,56 @@ FROM "issues"
 LEFT JOIN "users" ON
   "issues"."author" = "users"."id";
 ```
+
+## User-defined constants
+
+### Constant inlined into a condition
+
+> Show the issues created by user 1234. The `@user_id` constant is defined before the base table and
+> its value is inlined into the generated SQL.
+
+```qd
+@user_id = 1234
+#issues author:@user_id $title
+```
+
+```sql
+SELECT
+  "issues"."title"
+FROM "issues"
+WHERE
+  "issues"."author" = 1234;
+```
+
+### Constant inlined into an arithmetic expression
+
+> Show each issue's id offset by a constant amount.
+
+```qd
+@offset = 100
+#issues $id + @offset
+```
+
+```sql
+SELECT
+  "issues"."id" + 100
+FROM "issues";
+```
+
+### Constant referencing another constant
+
+> A constant's value may itself reference an earlier constant; both are inlined.
+
+```qd
+@base = 1000
+@user_id = @base
+#issues author:@user_id $title
+```
+
+```sql
+SELECT
+  "issues"."title"
+FROM "issues"
+WHERE
+  "issues"."author" = 1000;
+```

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -1870,3 +1870,75 @@ FROM "issues"
 WHERE
   "issues"."author" = 1000;
 ```
+
+## User-defined functions
+
+### Simple scalar function
+
+> Apply a user-defined `double` function to each issue's id. The function's body is inlined into the
+> generated SQL with its parameter bound to the piped-in argument.
+
+```qd
+@@double = @x => @x * 2
+#issues $id|double
+```
+
+```sql
+SELECT
+  "issues"."id" * 2
+FROM "issues";
+```
+
+### Function with multiple parameters
+
+> A function may take more than one parameter. When applied via a pipe, the piped-in value is the
+> first argument and any parenthesized values supply the rest.
+
+```qd
+@@add = @a @b => @a + @b
+#issues $id|add(100)
+```
+
+```sql
+SELECT
+  "issues"."id" + 100
+FROM "issues";
+```
+
+### Function containing an assignment
+
+> A function body may contain local assignments before its result expression. Here `is_adult`
+> computes an `age` assignment from its parameter and then compares it.
+
+```qd
+@@is_adult = @birth_date =>
+  @age = @birth_date|age|years|floor
+  @age:>=21
+#users $username $birth_date|is_adult
+```
+
+```sql
+SELECT
+  "users"."username",
+  FLOOR(EXTRACT(epoch FROM NOW() - "users"."birth_date") / 31557600) >= 21
+FROM "users";
+```
+
+### Function used within a condition
+
+> A user-defined function may be applied anywhere an expression is allowed, including conditions.
+
+```qd
+@@is_adult = @birth_date =>
+  @age = @birth_date|age|years|floor
+  @age:>=21
+#users birth_date|is_adult $username
+```
+
+```sql
+SELECT
+  "users"."username"
+FROM "users"
+WHERE
+  FLOOR(EXTRACT(epoch FROM NOW() - "users"."birth_date") / 31557600) >= 21;
+```

--- a/compiler/src/tests/definitions.rs
+++ b/compiler/src/tests/definitions.rs
@@ -1,0 +1,62 @@
+//! Unit tests for pre-base-table definitions (constants, functions, and custom comparisons) that
+//! assert behavior not captured by the SQL-string corpus — principally the error cases.
+
+use super::corpus_loader::build_options;
+use super::get_test_resource;
+use crate::Compiler;
+
+fn compile(input: &str) -> Result<String, String> {
+    let schema_json = get_test_resource("issue_schema.json");
+    let options = build_options(crate::options::IdentifierResolution::Flexible, "postgres");
+    let compiler = Compiler::new(&schema_json, options).unwrap();
+    compiler.compile(input.to_string()).map(|r| r.sql)
+}
+
+#[test]
+fn unknown_variable_is_rejected() {
+    let err = compile("#issues author:@missing").unwrap_err();
+    assert!(err.contains("missing"), "got: {err}");
+}
+
+#[test]
+fn constant_is_inlined() {
+    let sql = compile("@n = 1234\n#issues author:@n").unwrap();
+    assert!(sql.contains("= 1234"), "got: {sql}");
+}
+
+#[test]
+fn function_wrong_arg_count_is_rejected() {
+    // `add` expects two parameters, but the call supplies only one (the piped-in value).
+    let err = compile("@@add = @a @b => @a + @b\n#issues $id|add").unwrap_err();
+    assert!(err.contains("argument"), "got: {err}");
+}
+
+#[test]
+fn user_function_does_not_shadow_builtin() {
+    // A user-defined function named like a built-in is ignored in favor of the built-in.
+    let sql = compile("@@floor = @x => @x * 2\n#issues $id|floor").unwrap();
+    assert!(sql.contains("FLOOR"), "got: {sql}");
+    assert!(!sql.contains("* 2"), "got: {sql}");
+}
+
+#[test]
+fn custom_comparison_definition_with_unknown_table_is_rejected() {
+    let err = compile("#nonexistent.foo:@x = id:@x\n#issues $title").unwrap_err();
+    assert!(err.contains("nonexistent"), "got: {err}");
+}
+
+#[test]
+fn custom_comparison_operator_cannot_be_switched_when_body_uses_other_operators() {
+    // The body uses `:=`, so the comparison must be called exactly as defined (with `:`). Calling
+    // it with the regex operator is rejected.
+    let input = "#issues.participant:@x = author.username:=@x\n#issues participant:~david";
+    let err = compile(input).unwrap_err();
+    assert!(err.contains("participant"), "got: {err}");
+}
+
+#[test]
+fn custom_comparison_operator_can_be_switched_when_body_is_all_match() {
+    // The body uses only `:`, so the comparison may be called with a switched operator.
+    let input = "#issues.commenter:@x = ++#comments{user.username:@x}\n#issues commenter:=alice";
+    assert!(compile(input).is_ok());
+}

--- a/compiler/src/tests/mod.rs
+++ b/compiler/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod corpus;
 mod corpus_loader;
 #[cfg(feature = "db-tests")]
 mod db_corpus;
+mod definitions;
 mod grouping;
 mod test_utils;
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -886,8 +886,6 @@ to-one relationship, e.g. `#issues $author.can_purchase_alcohol`.
 
 ### User-defined functions
 
-_(🚧 Not yet implemented)_
-
 > Given a fiscal year which begins on February 1st, find issues that were opened in fiscal-year 2020 and marked due in 2021
 
 ```qd
@@ -895,9 +893,17 @@ _(🚧 Not yet implemented)_
 #issues created_at|fiscal_year:2020 due_date|fiscal_year:2021
 ```
 
+A function is defined before the base table with `@@name = @param1 @param2 => body`. It behaves like
+a built-in scalar function: it can be applied via a pipe (`value|name`) or with extra arguments
+(`value|name(extra)`), where the piped-in value becomes the first argument. When applied, the
+arguments are bound to the parameters and the body is **inlined** into the generated SQL. (Built-in
+functions take precedence over a user-defined function of the same name.)
+
 ### Function containing an assignment
 
-_(🚧 Not yet implemented)_
+A function body may contain local assignments (`@name = expr`) before its final result expression.
+The assignments and the result expression may reference the function's parameters as well as earlier
+assignments.
 
 ```qd
 @@generation = @birth_date =>

--- a/docs/language.md
+++ b/docs/language.md
@@ -923,8 +923,6 @@ assignments.
 
 ### Custom Comparisons
 
-_(🚧 Not yet implemented)_
-
 > Find issues that have a comment containing the word "workaround".
 
 ```

--- a/docs/language.md
+++ b/docs/language.md
@@ -845,14 +845,16 @@ $user.username%list
 
 ### User-defined constants
 
-_(🚧 Not yet implemented)_
-
 > Show the issues created by user 1234
 
 ```qd
 @user_id = 1234
 #issues author:@user_id
 ```
+
+A constant is defined before the base table with `@name = expr`. Its value is **inlined** into the
+generated SQL wherever the constant is referenced (as `@name`). A constant's definition may itself
+reference an earlier constant.
 
 ### Defining a constant using the result of a query
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -53,6 +53,9 @@ impl Serialize for AnnotationValue {
 
 #[derive(Debug, PartialEq)]
 pub struct Query {
+    /// User-defined constant definitions, written as `@name = expr` before the base table. Each
+    /// binds a name to an expression whose value is inlined wherever the constant is referenced.
+    pub constants: Vec<ConstantDef>,
     /// Computed column definitions, written before the base table. Each defines a named expression
     /// scoped to a table, which can then be referenced (by name) like a real column elsewhere in the
     /// query — including within the definitions of later computed columns.
@@ -65,6 +68,15 @@ pub struct Query {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ComputedColumn {
     pub table: String,
+    pub name: String,
+    pub expr: Expr,
+}
+
+/// A user-defined constant definition, written as `@name = expr` before the query's base table. The
+/// constant's value is inlined into the generated SQL wherever the constant is referenced (as
+/// `@name`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConstantDef {
     pub name: String,
     pub expr: Expr,
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -59,6 +59,10 @@ pub struct Query {
     /// User-defined function definitions, written as `@@name = @param => body` before the base
     /// table. Each is a scalar function that can be applied (by name) like a built-in function.
     pub functions: Vec<FunctionDef>,
+    /// User-defined custom comparison definitions, written as `#table.name:@param = body` before
+    /// the base table. Each defines a named comparison, scoped to a table, that can be used (by
+    /// name) like a real column on the left-hand side of a comparison.
+    pub custom_comparisons: Vec<CustomComparisonDef>,
     /// Computed column definitions, written before the base table. Each defines a named expression
     /// scoped to a table, which can then be referenced (by name) like a real column elsewhere in the
     /// query — including within the definitions of later computed columns.
@@ -110,6 +114,21 @@ pub struct FunctionBody {
 pub struct Assignment {
     pub name: String,
     pub expr: Expr,
+}
+
+/// A user-defined custom comparison definition, written as `#table.name:@param = body` before the
+/// query's base table. When `name` is used on the left-hand side of a comparison against a value,
+/// the value is bound to `param` and `body` is expanded in its place.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CustomComparisonDef {
+    pub table: String,
+    pub name: String,
+    /// The operator used in the definition (between the name and the parameter). Whether a call may
+    /// use a different operator depends on this and on the operators used within `body`.
+    pub operator: Operator,
+    /// The parameter name, without the `@` sigil.
+    pub param: String,
+    pub body: Expr,
 }
 
 #[derive(Debug, PartialEq, Default)]

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -56,6 +56,9 @@ pub struct Query {
     /// User-defined constant definitions, written as `@name = expr` before the base table. Each
     /// binds a name to an expression whose value is inlined wherever the constant is referenced.
     pub constants: Vec<ConstantDef>,
+    /// User-defined function definitions, written as `@@name = @param => body` before the base
+    /// table. Each is a scalar function that can be applied (by name) like a built-in function.
+    pub functions: Vec<FunctionDef>,
     /// Computed column definitions, written before the base table. Each defines a named expression
     /// scoped to a table, which can then be referenced (by name) like a real column elsewhere in the
     /// query — including within the definitions of later computed columns.
@@ -77,6 +80,34 @@ pub struct ComputedColumn {
 /// `@name`).
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConstantDef {
+    pub name: String,
+    pub expr: Expr,
+}
+
+/// A user-defined function definition, written as `@@name = @param1 @param2 => body` before the
+/// query's base table. The function is a scalar function: when applied, its arguments are bound to
+/// the parameters and its body is inlined into the generated SQL.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionDef {
+    pub name: String,
+    /// Parameter names, without the `@` sigil, in order.
+    pub params: Vec<String>,
+    pub body: FunctionBody,
+}
+
+/// The body of a [`FunctionDef`]: zero or more local assignments followed by a single result
+/// expression. The assignments and the result expression may reference the function's parameters as
+/// well as any earlier assignments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionBody {
+    pub assignments: Vec<Assignment>,
+    pub expr: Expr,
+}
+
+/// A local assignment within a function body, written as `@name = expr`. It binds a name to an
+/// expression for use later in the same function body.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assignment {
     pub name: String,
     pub expr: Expr,
 }

--- a/parser/src/parser/expr/comparison.rs
+++ b/parser/src/parser/expr/comparison.rs
@@ -60,7 +60,7 @@ fn range<'src>(expr: impl Psr<'src, Expr>) -> impl Psr<'src, Range> {
         .map(|(lower, upper)| Range { lower, upper })
 }
 
-fn operator<'src>() -> impl Psr<'src, Operator> {
+pub fn operator<'src>() -> impl Psr<'src, Operator> {
     choice((
         // Three character
         exactly(COMPARE_GTE).to(Operator::Gte),

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -8,6 +8,7 @@ mod number;
 mod path;
 mod pipe;
 
+pub use comparison::operator as comparison_operator;
 pub use path::path_to_one;
 
 use chumsky::{prelude::*, text::*};

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -10,6 +10,7 @@ use super::{column_layout::result_columns, expr::expr, sorting::sorting};
 /// (before the base table) and are parsed together, then sorted into the [`Query`]'s fields.
 enum Definition {
     Constant(ConstantDef),
+    Function(FunctionDef),
     ComputedColumn(ComputedColumn),
 }
 
@@ -30,15 +31,18 @@ pub fn query<'src>() -> impl Psr<'src, Query> {
             .then_ignore(pad().then(end()))
             .map(|((definitions, base_table), transformations)| {
                 let mut constants = vec![];
+                let mut functions = vec![];
                 let mut computed_columns = vec![];
                 for definition in definitions {
                     match definition {
                         Definition::Constant(c) => constants.push(c),
+                        Definition::Function(f) => functions.push(f),
                         Definition::ComputedColumn(c) => computed_columns.push(c),
                     }
                 }
                 Query {
                     constants,
+                    functions,
                     computed_columns,
                     base_table,
                     transformations,
@@ -50,6 +54,9 @@ pub fn query<'src>() -> impl Psr<'src, Query> {
 /// Parses any of the definitions that may precede the base table.
 fn definition<'src>() -> impl Psr<'src, Definition> {
     choice((
+        // `function` is tried before `constant` because both begin with `@`; the `@@` prefix of a
+        // function would otherwise be misread as the start of a constant.
+        function().map(Definition::Function),
         constant().map(Definition::Constant),
         computed_column().map(Definition::ComputedColumn),
     ))
@@ -63,6 +70,51 @@ fn constant<'src>() -> impl Psr<'src, ConstantDef> {
         .then_ignore(pad().then(just(DEFINITION_ASSIGN)).then(pad()))
         .then(expr())
         .map(|(name, expr)| ConstantDef { name, expr })
+}
+
+/// Parses a variable reference's name, e.g. the `date` in `@date`.
+fn variable_name<'src>() -> impl Psr<'src, String> {
+    just(CONST_SIGIL).ignore_then(ident().map(|s: &str| s.to_string()))
+}
+
+/// Parses one user-defined function definition, e.g. `@@fiscal_year = @date => (@date - @1M)|year`.
+/// The body is zero or more local assignments followed by a single result expression. Parameters
+/// and assignments are referenced (within the body) as variables.
+fn function<'src>() -> impl Psr<'src, FunctionDef> {
+    let params = variable_name()
+        .separated_by(pad())
+        .at_least(1)
+        .collect::<Vec<String>>();
+    exactly(FUNCTION_SIGIL)
+        .ignore_then(ident().map(|s: &str| s.to_string()))
+        .then_ignore(pad().then(just(DEFINITION_ASSIGN)).then(pad()))
+        .then(params)
+        .then_ignore(pad().then(exactly(FUNCTION_ARROW)).then(pad()))
+        .then(function_body())
+        .map(|((name, params), body)| FunctionDef { name, params, body })
+}
+
+/// Parses a function body: zero or more local assignments followed by the result expression.
+fn function_body<'src>() -> impl Psr<'src, FunctionBody> {
+    assignment()
+        .then_ignore(pad())
+        .repeated()
+        .collect::<Vec<Assignment>>()
+        .then(expr())
+        .map(|(assignments, expr)| FunctionBody { assignments, expr })
+}
+
+/// Parses a local assignment within a function body, e.g. `@birth_year = @birth_date|year`. An
+/// assignment is distinguished from the body's result expression by the `=` that follows its name.
+fn assignment<'src>() -> impl Psr<'src, Assignment> {
+    variable_name()
+        .then_ignore(pad())
+        // Match a `=` that does not begin a `=>` arrow (defensive: arrows only appear in the
+        // parameter list, never within the body).
+        .then_ignore(just(DEFINITION_ASSIGN).then_ignore(just('>').not()))
+        .then_ignore(pad())
+        .then(expr())
+        .map(|(name, expr)| Assignment { name, expr })
 }
 
 /// Parses one computed column definition, e.g. `#users.age = birth_date|age|years|floor`. These are
@@ -112,6 +164,7 @@ mod tests {
             query().parse("#foo a:1 b:2 $c").into_result(),
             Ok(Query {
                 constants: vec![],
+                functions: vec![],
                 computed_columns: vec![],
                 base_table: "foo".to_string(),
                 transformations: vec![Transformation {
@@ -205,5 +258,55 @@ mod tests {
             }]
         );
         assert!(result.computed_columns.is_empty());
+    }
+
+    #[test]
+    fn test_parse_query_with_function() {
+        // A function definition with a single parameter and no local assignments.
+        let result = query()
+            .parse("@@double = @x => @x * 2\n#issues $id|double")
+            .into_result()
+            .unwrap();
+        assert_eq!(result.base_table, "issues".to_string());
+        assert_eq!(result.functions.len(), 1);
+        let func = &result.functions[0];
+        assert_eq!(func.name, "double".to_string());
+        assert_eq!(func.params, vec!["x".to_string()]);
+        assert!(func.body.assignments.is_empty());
+        assert_eq!(
+            func.body.expr,
+            Expr::Product(
+                Box::new(Expr::Variable("x".to_string())),
+                Box::new(Expr::Number("2".to_string())),
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_query_with_function_containing_assignment() {
+        // A function body may contain local assignments before the result expression.
+        let result = query()
+            .parse("@@f = @a @b =>\n  @s = @a + @b\n  @s * 2\n#issues $id|f(2 3)")
+            .into_result()
+            .unwrap();
+        let func = &result.functions[0];
+        assert_eq!(func.name, "f".to_string());
+        assert_eq!(func.params, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(func.body.assignments.len(), 1);
+        assert_eq!(func.body.assignments[0].name, "s".to_string());
+        assert_eq!(
+            func.body.assignments[0].expr,
+            Expr::Sum(
+                Box::new(Expr::Variable("a".to_string())),
+                Box::new(Expr::Variable("b".to_string())),
+            )
+        );
+        assert_eq!(
+            func.body.expr,
+            Expr::Product(
+                Box::new(Expr::Variable("s".to_string())),
+                Box::new(Expr::Number("2".to_string())),
+            )
+        );
     }
 }

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -1,4 +1,4 @@
-use chumsky::prelude::*;
+use chumsky::{prelude::*, text::*};
 
 use crate::ast::*;
 use crate::tokens::*;
@@ -6,27 +6,63 @@ use crate::tokens::*;
 use super::utils::*;
 use super::{column_layout::result_columns, expr::expr, sorting::sorting};
 
+/// A pre-base-table definition. Several kinds of definition share the same position in the source
+/// (before the base table) and are parsed together, then sorted into the [`Query`]'s fields.
+enum Definition {
+    Constant(ConstantDef),
+    ComputedColumn(ComputedColumn),
+}
+
 pub fn query<'src>() -> impl Psr<'src, Query> {
-    let computed_columns = computed_column()
+    let definitions = definition()
         .then_ignore(pad())
         .repeated()
-        .collect::<Vec<ComputedColumn>>();
+        .collect::<Vec<Definition>>();
     let base_table = just(TABLE_SIGIL).ignore_then(db_identifier());
     let transformations = transformation()
         .separated_by(pad().then(exactly(TRANSFORMATION_DELIMITER)).then(pad()))
         .collect::<Vec<Transformation>>();
     pad().ignore_then(
-        computed_columns
+        definitions
             .then(base_table)
             .then_ignore(pad())
             .then(transformations)
             .then_ignore(pad().then(end()))
-            .map(|((computed_columns, base_table), transformations)| Query {
-                computed_columns,
-                base_table,
-                transformations,
+            .map(|((definitions, base_table), transformations)| {
+                let mut constants = vec![];
+                let mut computed_columns = vec![];
+                for definition in definitions {
+                    match definition {
+                        Definition::Constant(c) => constants.push(c),
+                        Definition::ComputedColumn(c) => computed_columns.push(c),
+                    }
+                }
+                Query {
+                    constants,
+                    computed_columns,
+                    base_table,
+                    transformations,
+                }
             }),
     )
+}
+
+/// Parses any of the definitions that may precede the base table.
+fn definition<'src>() -> impl Psr<'src, Definition> {
+    choice((
+        constant().map(Definition::Constant),
+        computed_column().map(Definition::ComputedColumn),
+    ))
+}
+
+/// Parses one user-defined constant definition, e.g. `@user_id = 1234`. The right-hand side is a
+/// single expression whose value gets inlined wherever the constant is referenced.
+fn constant<'src>() -> impl Psr<'src, ConstantDef> {
+    just(CONST_SIGIL)
+        .ignore_then(ident().map(|s: &str| s.to_string()))
+        .then_ignore(pad().then(just(DEFINITION_ASSIGN)).then(pad()))
+        .then(expr())
+        .map(|(name, expr)| ConstantDef { name, expr })
 }
 
 /// Parses one computed column definition, e.g. `#users.age = birth_date|age|years|floor`. These are
@@ -75,6 +111,7 @@ mod tests {
         assert_eq!(
             query().parse("#foo a:1 b:2 $c").into_result(),
             Ok(Query {
+                constants: vec![],
                 computed_columns: vec![],
                 base_table: "foo".to_string(),
                 transformations: vec![Transformation {
@@ -150,5 +187,23 @@ mod tests {
                 right: ComparisonSide::Expr(Expr::Number("21".to_string())),
             }))
         );
+    }
+
+    #[test]
+    fn test_parse_query_with_constants() {
+        // Constant definitions precede the base table and bind a name to an expression.
+        let result = query()
+            .parse("@user_id = 1234\n#issues author:@user_id")
+            .into_result()
+            .unwrap();
+        assert_eq!(result.base_table, "issues".to_string());
+        assert_eq!(
+            result.constants,
+            vec![ConstantDef {
+                name: "user_id".to_string(),
+                expr: Expr::Number("1234".to_string()),
+            }]
+        );
+        assert!(result.computed_columns.is_empty());
     }
 }

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -4,13 +4,16 @@ use crate::ast::*;
 use crate::tokens::*;
 
 use super::utils::*;
-use super::{column_layout::result_columns, expr::expr, sorting::sorting};
+use super::{
+    column_layout::result_columns, expr::comparison_operator, expr::expr, sorting::sorting,
+};
 
 /// A pre-base-table definition. Several kinds of definition share the same position in the source
 /// (before the base table) and are parsed together, then sorted into the [`Query`]'s fields.
 enum Definition {
     Constant(ConstantDef),
     Function(FunctionDef),
+    CustomComparison(CustomComparisonDef),
     ComputedColumn(ComputedColumn),
 }
 
@@ -32,17 +35,20 @@ pub fn query<'src>() -> impl Psr<'src, Query> {
             .map(|((definitions, base_table), transformations)| {
                 let mut constants = vec![];
                 let mut functions = vec![];
+                let mut custom_comparisons = vec![];
                 let mut computed_columns = vec![];
                 for definition in definitions {
                     match definition {
                         Definition::Constant(c) => constants.push(c),
                         Definition::Function(f) => functions.push(f),
+                        Definition::CustomComparison(c) => custom_comparisons.push(c),
                         Definition::ComputedColumn(c) => computed_columns.push(c),
                     }
                 }
                 Query {
                     constants,
                     functions,
+                    custom_comparisons,
                     computed_columns,
                     base_table,
                     transformations,
@@ -58,6 +64,9 @@ fn definition<'src>() -> impl Psr<'src, Definition> {
         // function would otherwise be misread as the start of a constant.
         function().map(Definition::Function),
         constant().map(Definition::Constant),
+        // `custom_comparison` is tried before `computed_column` because both begin with
+        // `#table.name`; only the operator that follows the name distinguishes them.
+        custom_comparison().map(Definition::CustomComparison),
         computed_column().map(Definition::ComputedColumn),
     ))
 }
@@ -130,6 +139,30 @@ fn computed_column<'src>() -> impl Psr<'src, ComputedColumn> {
         .map(|((table, name), expr)| ComputedColumn { table, name, expr })
 }
 
+/// Parses one custom comparison definition, e.g. `#issues.comment:@x = ++#comments{body:@x}`. The
+/// comparison operator (here `:`) sits between the name and the parameter, and the body — in which
+/// the parameter may be referenced — follows the `=`.
+fn custom_comparison<'src>() -> impl Psr<'src, CustomComparisonDef> {
+    just(TABLE_SIGIL)
+        .ignore_then(db_identifier())
+        .then_ignore(just(PATH_SEPARATOR))
+        .then(db_identifier())
+        .then(comparison_operator())
+        .then_ignore(pad())
+        .then(variable_name())
+        .then_ignore(pad().then(just(DEFINITION_ASSIGN)).then(pad()))
+        .then(expr())
+        .map(
+            |((((table, name), operator), param), body)| CustomComparisonDef {
+                table,
+                name,
+                operator,
+                param,
+                body,
+            },
+        )
+}
+
 fn transformation<'src>() -> impl Psr<'src, Transformation> {
     top_level_condition_set()
         .then_ignore(pad())
@@ -165,6 +198,7 @@ mod tests {
             Ok(Query {
                 constants: vec![],
                 functions: vec![],
+                custom_comparisons: vec![],
                 computed_columns: vec![],
                 base_table: "foo".to_string(),
                 transformations: vec![Transformation {
@@ -307,6 +341,41 @@ mod tests {
                 Box::new(Expr::Variable("s".to_string())),
                 Box::new(Expr::Number("2".to_string())),
             )
+        );
+    }
+
+    #[test]
+    fn test_parse_query_with_custom_comparison() {
+        let result = query()
+            .parse("#issues.comment:@x = ++#comments{body:@x}\n#issues comment:workaround")
+            .into_result()
+            .unwrap();
+        assert_eq!(result.base_table, "issues".to_string());
+        assert_eq!(result.custom_comparisons.len(), 1);
+        let def = &result.custom_comparisons[0];
+        assert_eq!(def.table, "issues".to_string());
+        assert_eq!(def.name, "comment".to_string());
+        assert_eq!(def.operator, Operator::Match);
+        assert_eq!(def.param, "x".to_string());
+        assert_eq!(
+            def.body,
+            Expr::HasQuantity(HasQuantity {
+                quantity: Quantity::AtLeastOne,
+                path_parts: vec![PathPart::TableWithMany(TableWithMany {
+                    table: "comments".to_string(),
+                    condition_set: ConditionSet {
+                        conjunction: Conjunction::And,
+                        entries: vec![Expr::Comparison(Box::new(Comparison {
+                            left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column(
+                                "body".to_string()
+                            )])),
+                            operator: Operator::Match,
+                            right: ComparisonSide::Expr(Expr::Variable("x".to_string())),
+                        }))]
+                    },
+                    linking_column: None,
+                })]
+            })
         );
     }
 }

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -44,6 +44,11 @@ pub(crate) const CONDITION_SET_OR_BRACE_R: char = ']';
 /// `foo:1,bar:2`. This has the lowest precedence of any operator.
 pub(crate) const CONDITION_SET_OR_SHORTHAND: char = ',';
 pub(crate) const CONST_SIGIL: char = '@';
+/// Prefix introducing a user-defined function definition, e.g. `@@fiscal_year = @date => ...`.
+pub(crate) const FUNCTION_SIGIL: &str = "@@";
+/// Separates a user-defined function's parameter list from its body, e.g. the `=>` in
+/// `@date => (@date - @1M)|year`.
+pub(crate) const FUNCTION_ARROW: &str = "=>";
 /// Separates the left-hand side of a definition from its value, e.g. the `=` in a computed column
 /// definition `#users.age = birth_date|age|years|floor`.
 pub(crate) const DEFINITION_ASSIGN: char = '=';


### PR DESCRIPTION
This implements three of the user-defined "variables" features documented in `docs/language.md`, each in its own commit.

## 1. User-defined constants

```qd
@user_id = 1234
#issues author:@user_id
```

A constant is defined before the base table with `@name = expr`. Its value is **inlined** into the generated SQL wherever the constant is referenced. A constant's definition may itself reference an earlier constant.

## 2. User-defined functions

```qd
@@double = @x => @x * 2
#issues $id|double
```

A function is defined with `@@name = @param1 @param2 => body`. It behaves like a built-in scalar function: it can be applied via a pipe (`value|name`) or with extra arguments (`value|name(extra)`), where the piped-in value becomes the first argument. Arguments are bound to the parameters and the body is **inlined** into the generated SQL. Built-in functions take precedence over a user-defined function of the same name.

Function bodies may contain local assignments before the result expression:

```qd
@@is_adult = @birth_date =>
  @age = @birth_date|age|years|floor
  @age:>=21
#users $username $birth_date|is_adult
```

## 3. Custom comparisons

```qd
#issues.comment:@x = ++#comments{body:@x}
#issues comment:workaround
```

Using a custom comparison's name on the left-hand side of a comparison binds the right-hand value to the parameter and expands the body in place. When a comparison is defined with `:` and every comparison in its body also uses `:`, callers may switch the operator (e.g. `comment:~"work[ -]?around"` or `comment:="+1"`), which is substituted throughout the body. Otherwise it must be called exactly as defined.

## Implementation notes

- All three definition kinds are parsed before the base table and sorted into their respective `Query` fields. The parser shares a single `definition` combinator.
- Constants and function parameters/locals are resolved through a single scope-level variable-binding mechanism; function/comparison bodies are inlined by substituting bound AST expressions and compiling them in place.
- The docs are updated to drop the "🚧 Not yet implemented" markers for each feature.

## Tests

- Parser unit tests for each new definition form.
- Compiler corpus tests (`corpus.md`) covering inlining, multiple parameters, assignment-containing functions, and operator switching for custom comparisons.
- Compiler unit tests (`definitions.rs`) for the error cases (unknown variable, wrong arg count, built-in shadowing, unknown table, operator-switch rules).

`cargo check`, `cargo clippy`, `cargo build`, `cargo test`, and `cargo fmt` all pass. The `db-tests` feature could not be exercised in this environment because the Postgres `initdb` binary is not available here; all string-match corpus and unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnEfu6DVmeNUEgQRuG5zmD)_