### PR TITLE
Drop sigil and T separator from duration literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _(The bullet points above correspond, line for line, with the querydown code bel
 
 ```text
 #issues
-created_at:>@6M|ago
+created_at:>6m|ago
 --#assignments
 ++#labels{name:..["Regression" "Bug"]}
 10..20:#comments{user.team.name!"Backend"}

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -44,7 +44,7 @@ SELECT "Patrons".* FROM "Patrons";
 
 ```qd
 #issues
-created_at:>@6M|ago
+created_at:>6m|ago
 --#assignments
 ++#labels{name:..["Regression" "Bug"]}
 10..20:#comments{!user.team.name:"Backend"}
@@ -82,7 +82,7 @@ FROM "Checkouts";
 > Checkouts from over one month ago and not yet returned
 
 ```qd
-#checkouts check_in_time:@null check_out_time:<@1M|ago
+#checkouts check_in_time:@null check_out_time:<1m|ago
 ```
 
 ```sql
@@ -99,7 +99,7 @@ WHERE
 > Checkouts from over one month ago and not yet returned
 
 ```qd
-#checkouts checkInTime:@null checkOutTime:<@1M|ago
+#checkouts checkInTime:@null checkOutTime:<1m|ago
 ```
 
 ```sql
@@ -165,7 +165,7 @@ WHERE
 ### Duration
 
 ```qd
-#issues created_at:>@6Y|ago
+#issues created_at:>6y|ago
 ```
 
 ```sql
@@ -176,10 +176,12 @@ WHERE
   "issues"."created_at" > NOW() - make_interval(years => 6);
 ```
 
-### Duration, lowercase
+### Duration, uppercase
+
+> Duration units are case-insensitive.
 
 ```qd
-#issues created_at:>@6y|ago
+#issues created_at:>6Y|ago
 ```
 
 ```sql
@@ -315,7 +317,7 @@ dialect = "duckdb"
 > DuckDB has no `make_interval`, so a single-part duration uses a `to_*` function.
 
 ```qd
-#issues created_at:>@6Y|ago
+#issues created_at:>6y|ago
 ```
 
 ```sql
@@ -335,7 +337,7 @@ dialect = "duckdb"
 > A multi-part duration sums `to_*` functions, parenthesized so it stays atomic when subtracted.
 
 ```qd
-#issues created_at:>@1Y2D|ago
+#issues created_at:>1y2d|ago
 ```
 
 ```sql
@@ -415,7 +417,7 @@ WHERE
 ### Range containing pipes
 
 ```qd
-#issues created_at:(@2Y|ago)..(@1Y|ago)
+#issues created_at:(2y|ago)..(1y|ago)
 ```
 
 ```sql
@@ -1115,7 +1117,7 @@ TODO
 > Users who have not created any issues in the past year
 
 ```qd
-#users --#issues{created_at:>@1Y|ago}
+#users --#issues{created_at:>1y|ago}
 ```
 
 ```sql
@@ -1142,7 +1144,7 @@ WHERE
 > Users, showing the number of issues created in the past year
 
 ```qd
-#users $#issues{created_at:>@1Y|ago}
+#users $#issues{created_at:>1y|ago}
 ```
 
 ```sql

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -28,7 +28,7 @@ _See the **[Language Guide](./language.md)** for more detail._
 | -- | -- | -- |
 | `//` `/* */` | code comments | ✅ |
 | `@2000-01-01` | [dates](./language.md#date-literals) | ✅ |
-| `@1y` | [durations](./language.md#duration-literals) | ✅ |
+| `1y` | [durations](./language.md#duration-literals) | ✅ |
 | `@` | sigil for [built-in](./language.md#built-in-constants) and [user-defined](./language.md#user-defined-constants) constants | ✅ |
 | `..` `..<` `<..` `<..<` | [ranges](./language.md#ranges) | ✅ |
 | `"` or `'` | string quote | ✅ |

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -224,7 +224,7 @@ Returns the interval elapsed _since_ a past timestamp, compiling to `NOW() - val
 Returns the timestamp that lies a given duration _in the past_, compiling to `NOW() - value`. Typically applied to a [duration literal](./language.md#duration-literals) within a condition.
 
 ```qd
-#issues created_at:>@6M|ago // created within the last 6 months
+#issues created_at:>6m|ago // created within the last 6 months
 ```
 
 _(`age` and `ago` are equivalent; the two names exist for readability depending on whether you apply the function to a date or to a duration.)_

--- a/docs/language.md
+++ b/docs/language.md
@@ -175,17 +175,30 @@ Literal dates and timestamps can be written in [ISO-8601](https://en.wikipedia.o
 
 ### Duration literals
 
-Literal durations can be written in case-insensitive [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) without the `P` prefix and with a `@` prefix.
+A literal duration is a non-empty sequence of parts, where each part is a number immediately followed by a case-insensitive unit. The units are:
 
-| Example | Meaning |
-| --      | -- |
-| `@2y`   | 2 years |
-| `@2.5y` | 2.5 years |
-| `@1y2d` | 1 year and 2 days |
-| `@9m`   | 9 months |
-| `@t9m`  | 9 minutes |
-| `@t1h`  | 1 hour |
-| `@0y`   | (empty) |
+| Unit  | Meaning |
+| --    | --      |
+| `y`   | years   |
+| `m`   | months  |
+| `w`   | weeks   |
+| `d`   | days    |
+| `h`   | hours   |
+| `min` | minutes |
+| `s`   | seconds |
+
+Note that `m` always means months and `min` always means minutes, so the two are never ambiguous.
+
+| Example         | Meaning |
+| --              | -- |
+| `2y`            | 2 years |
+| `2.5y`          | 2.5 years |
+| `1y2d`          | 1 year and 2 days |
+| `9m`            | 9 months |
+| `9min`          | 9 minutes |
+| `1h`            | 1 hour |
+| `2y6m3d8h9min34.89s` | 2 years, 6 months, 3 days, 8 hours, 9 minutes, and 34.89 seconds |
+| `0y`            | (empty) |
 
 
 ## Computations
@@ -889,7 +902,7 @@ to-one relationship, e.g. `#issues $author.can_purchase_alcohol`.
 > Given a fiscal year which begins on February 1st, find issues that were opened in fiscal-year 2020 and marked due in 2021
 
 ```qd
-@@fiscal_year = @date => (@date - @1M)|year
+@@fiscal_year = @date => (@date - 1m)|year
 #issues created_at|fiscal_year:2020 due_date|fiscal_year:2021
 ```
 
@@ -1032,7 +1045,7 @@ Annotations are written in a JSON-like syntax with a few differences from standa
 A few things to watch out for:
 
 - Bare `true`, `false`, and `null` (without the `@` sigil) are parsed as the **strings** `"true"`, `"false"`, and `"null"`.
-- Inside an annotation, the `@` sigil accepts **only** `true`/`false`/`null` — not dates (`@2000-01-01`), durations (`@2y`), or other constants.
+- Inside an annotation, the `@` sigil accepts **only** `true`/`false`/`null` — not dates (`@2000-01-01`) or other constants.
 - A value that begins with a digit is parsed as a number, and a value that begins with `#` (such as a color like `#fbc9ff`) must be quoted.
 
 ### Query-level annotations

--- a/parser/src/parser/annotation.rs
+++ b/parser/src/parser/annotation.rs
@@ -186,7 +186,8 @@ mod tests {
     #[test]
     fn test_rejects_non_json_constants() {
         assert!(p("@{a:@now}").is_err());
-        assert!(p("@{a:@2y}").is_err());
+        // A duration (now written without a sigil) is likewise not a valid annotation value.
+        assert!(p("@{a:2y}").is_err());
     }
 
     #[test]

--- a/parser/src/parser/expr/duration.rs
+++ b/parser/src/parser/expr/duration.rs
@@ -7,45 +7,59 @@ use chumsky::prelude::*;
 
 use crate::ast::*;
 use crate::parser::utils::*;
-use crate::tokens::*;
 
+/// Parses a duration literal, e.g. `2y6m3d8h9min34.89s`.
+///
+/// A duration is a non-empty sequence of parts, where each part is a number immediately followed by
+/// a unit. The units are case-insensitive:
+///
+/// | Unit  | Meaning |
+/// | --    | --      |
+/// | `y`   | years   |
+/// | `m`   | months  |
+/// | `w`   | weeks   |
+/// | `d`   | days    |
+/// | `h`   | hours   |
+/// | `min` | minutes |
+/// | `s`   | seconds |
+///
+/// Note that `m` always means months and `min` always means minutes, so the two are never
+/// ambiguous. Because every part begins with a digit, durations never collide with column
+/// references (which begin with a letter). A digit-initial token with no trailing unit is not a
+/// duration — it falls through to the number parser — so `duration` must be tried before `number`.
 pub fn duration<'src>() -> impl Psr<'src, Duration> {
     let case_insensitive =
         |uppercase: char| choice((just(uppercase), just(uppercase.to_ascii_lowercase())));
 
-    let part = |c: char| positive_float().then_ignore(case_insensitive(c));
+    // The minutes unit `min` must be tried before the months unit `m`; otherwise `m` would greedily
+    // match the leading character of `min`. Chumsky rewinds on a failed alternative, so trying
+    // `min` first is safe: e.g. for `m3d`, matching `min` consumes `m`, fails on `3`, rewinds, and
+    // then `m` matches as months.
+    let minutes = case_insensitive('M')
+        .ignore_then(case_insensitive('I'))
+        .ignore_then(case_insensitive('N'))
+        .to(Minute);
+    let unit = choice((
+        minutes,
+        case_insensitive('Y').to(Year),
+        case_insensitive('M').to(Month),
+        case_insensitive('W').to(Week),
+        case_insensitive('D').to(Day),
+        case_insensitive('H').to(Hour),
+        case_insensitive('S').to(Second),
+    ));
 
-    let large_part = choice((
-        part('Y').map(|value| Part { kind: Year, value }),
-        part('M').map(|value| Part { kind: Month, value }),
-        part('W').map(|value| Part { kind: Week, value }),
-        part('D').map(|value| Part { kind: Day, value }),
-    ));
-    #[rustfmt::skip]
-    let small_part = choice((
-        part('H').map(|value| Part { kind: Hour, value }),
-        part('M').map(|value| Part { kind: Minute, value }),
-        part('S').map(|value| Part { kind: Second, value }),
-    ));
-    just(CONST_SIGIL).ignore_then(
-        large_part
-            .repeated()
-            .collect::<Vec<Part>>()
-            .then(
-                case_insensitive('T')
-                    .ignore_then(small_part.repeated().at_least(1).collect::<Vec<Part>>())
-                    .or_not(),
-            )
-            .try_map(|(mut large, small), span| {
-                if let Some(small) = small {
-                    large.extend(small);
-                }
-                assemble(large).map_err(|s| Rich::custom(span, s))
-            }),
-    )
+    let part = positive_float()
+        .then(unit)
+        .map(|(value, kind)| Part { kind, value });
+
+    part.repeated()
+        .at_least(1)
+        .collect::<Vec<Part>>()
+        .try_map(|parts, span| assemble(parts).map_err(|s| Rich::custom(span, s)))
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Kind {
     Year,
     Month,
@@ -114,7 +128,7 @@ mod tests {
                 .map_err(|_| ())
         };
         assert_eq!(
-            parse("@1Y2.2M0.3W4444DT5H6M7S"),
+            parse("1y2.2m0.3w4444d5h6min7s"),
             Ok(Duration {
                 years: 1.0,
                 months: 2.2,
@@ -125,19 +139,37 @@ mod tests {
                 seconds: 7.0,
             })
         );
-        assert_eq!(parse("@0Y"), Ok(Duration::default()));
-        assert_eq!(parse("@T0S"), Ok(Duration::default()));
-        assert!(parse("@1M").is_ok());
-        assert!(parse("@T1M").is_ok());
-        assert!(parse("@1MT1M").is_ok());
-        assert!(parse("@").is_err());
-        assert!(parse("@1").is_err());
-        assert!(parse("@1YY").is_err());
-        assert!(parse("@1T").is_err());
-        assert!(parse("@1YT").is_err());
-        assert!(parse("@1YT1").is_err());
-        assert!(parse("@1TM").is_err());
-        assert!(parse("@1Y2Y").is_err());
-        assert!(parse("@1Y0Y").is_err());
+        // Units are case-insensitive, and parts may appear in any order.
+        assert_eq!(
+            parse("6MIN2Y"),
+            Ok(Duration {
+                years: 2.0,
+                minutes: 6.0,
+                ..Default::default()
+            })
+        );
+        assert_eq!(parse("0y"), Ok(Duration::default()));
+        assert_eq!(parse("0s"), Ok(Duration::default()));
+        // `m` is months and `min` is minutes; the two are unambiguous, even adjacent.
+        assert_eq!(
+            parse("1m1min"),
+            Ok(Duration {
+                months: 1.0,
+                minutes: 1.0,
+                ..Default::default()
+            })
+        );
+        assert!(parse("1m").is_ok());
+        assert!(parse("1min").is_ok());
+        // An empty string or a unit-less number is not a duration.
+        assert!(parse("").is_err());
+        assert!(parse("1").is_err());
+        // A trailing or repeated unit character is invalid.
+        assert!(parse("1yy").is_err());
+        assert!(parse("1y2").is_err());
+        // A duration can't repeat a kind.
+        assert!(parse("1y2y").is_err());
+        assert!(parse("1y0y").is_err());
+        assert!(parse("1m1m").is_err());
     }
 }

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -51,9 +51,11 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
     // far enough to OOM the build. Boxing is semantically transparent and also speeds up compiles.
     recursive(|prec_comma| {
         let prec_atom = choice((
+            // `duration` is tried before `number` because both begin with a digit. A duration
+            // requires a trailing unit (e.g. `6m`), so a unit-less number like `6` falls through.
+            duration().map(Expr::Duration),
             number().map(Expr::Number),
             date().map(Expr::Date),
-            duration().map(Expr::Duration),
             string().map(Expr::String),
             variable().map(Expr::Variable),
             path(prec_comma.clone()).map(Expr::Path),
@@ -75,9 +77,10 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
         // side is interpreted as a string literal rather than a column reference. See
         // `comparison_rhs_value` for details.
         let prec_atom_rhs = choice((
+            // See the ordering note on `prec_atom` above: `duration` before `number`.
+            duration().map(Expr::Duration),
             number().map(Expr::Number),
             date().map(Expr::Date),
-            duration().map(Expr::Duration),
             string().map(Expr::String),
             variable().map(Expr::Variable),
             comparison_rhs_value(prec_comma.clone()),
@@ -219,12 +222,14 @@ mod tests {
             }))
         );
         assert_eq!(
-            p("@1Y"),
+            p("1y"),
             Ok(Expr::Duration(Duration {
                 years: 1.0,
                 ..Default::default()
             }))
         );
+        // A digit-initial token with no unit is a plain number, not a duration.
+        assert_eq!(p("6"), Ok(Expr::Number("6".to_string())));
         assert_eq!(p("'foo'"), Ok(Expr::String("foo".to_string())));
         assert_eq!(p("\"foo\""), Ok(Expr::String("foo".to_string())));
         assert_eq!(p("@foo"), Ok(Expr::Variable("foo".to_string())));

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -86,7 +86,7 @@ fn variable_name<'src>() -> impl Psr<'src, String> {
     just(CONST_SIGIL).ignore_then(ident().map(|s: &str| s.to_string()))
 }
 
-/// Parses one user-defined function definition, e.g. `@@fiscal_year = @date => (@date - @1M)|year`.
+/// Parses one user-defined function definition, e.g. `@@fiscal_year = @date => (@date - 1m)|year`.
 /// The body is zero or more local assignments followed by a single result expression. Parameters
 /// and assignments are referenced (within the body) as variables.
 fn function<'src>() -> impl Psr<'src, FunctionDef> {

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -47,7 +47,7 @@ pub(crate) const CONST_SIGIL: char = '@';
 /// Prefix introducing a user-defined function definition, e.g. `@@fiscal_year = @date => ...`.
 pub(crate) const FUNCTION_SIGIL: &str = "@@";
 /// Separates a user-defined function's parameter list from its body, e.g. the `=>` in
-/// `@date => (@date - @1M)|year`.
+/// `@date => (@date - 1m)|year`.
 pub(crate) const FUNCTION_ARROW: &str = "=>";
 /// Separates the left-hand side of a definition from its value, e.g. the `=` in a computed column
 /// definition `#users.age = birth_date|age|years|floor`.

--- a/site/src/routes/(fit-viewport)/playground/constants.ts
+++ b/site/src/routes/(fit-viewport)/playground/constants.ts
@@ -1,5 +1,5 @@
 export const starting_querydown = `#issues
-created_at:>@6M|ago
+created_at:>6m|ago
 --#assignments
 ++#labels{name:..["Regression" "Bug"]}
 10..20:#comments{user.team.name!"Backend"}

--- a/site/src/routes/(fit-viewport)/playground/monarch.ts
+++ b/site/src/routes/(fit-viewport)/playground/monarch.ts
@@ -24,7 +24,7 @@ export const qd_monarch: languages.IMonarchLanguage = {
       [/[{}()[\]]/, '@brackets'],
       [/(@identifier)/, 'column'],
       [/#(@identifier)/, 'table-with-many'],
-      [/@(\d+[ymdwthsYMDWTHS])+/, 'duration'],
+      [/(\d+(\.\d+)?(?:[mM][iI][nN]|[ymwdhsYMWDHS]))+/, 'duration'],
       [/@(@identifier)/, 'constant'],
       [/@\d\d\d\d-\d\d-\d\d/, 'date'],
 


### PR DESCRIPTION
## Summary

Reworks duration literal syntax. Durations are now a bare sequence of `<number><unit>` parts — no `@` sigil and no `T` separator.

**Before:** `@1Y2.2M0.3W4444DT5H6M7S`
**After:** `1y2.2m0.3w4444d5h6min7s`

### Unit table (case-insensitive)

| Unit  | Meaning |
| --    | --      |
| `y`   | years   |
| `m`   | months  |
| `w`   | weeks   |
| `d`   | days    |
| `h`   | hours   |
| `min` | minutes |
| `s`   | seconds |

`m` always means months and `min` always means minutes, so the two are never ambiguous (`min` is matched before `m`, relying on Chumsky's backtracking on a failed alternative).

### Disambiguation

Every duration part begins with a digit, so durations never collide with column references (which begin with a letter). A digit-initial token with **no** trailing unit is a plain number — the duration parser requires at least one unit and otherwise fails — so `duration` is now tried **before** `number` in both the main and comparison-RHS atom chains.

### Changes

- `parser/src/parser/expr/duration.rs` — rewritten parser + tests
- `parser/src/parser/expr/mod.rs` — reordered atoms (`duration` before `number`); updated tests
- `parser/src/parser/annotation.rs`, `query.rs`, `tokens.rs` — updated examples/tests
- `compiler/src/tests/corpus.md` — converted duration literals (SQL output unchanged); the lowercase-variant case now tests uppercase for case-insensitivity coverage
- Docs: `language.md`, `cheat-sheet.md`, `functions.md`, `README.md`
- `site/.../playground/monarch.ts` + `constants.ts` — updated syntax highlighting and starting example

### Validation

`cargo check`, `clippy`, `build`, `test`, and `fmt` all pass. `cargo test --features db-tests` could not run here (the `initdb`/Postgres binary isn't present in this container); all 18 non-DB corpus cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G68pBLXp9n4cf1X6QpYaww)_