### PR TITLE
Add granular four-section parsing to the public API

### DIFF
--- a/compiler/src/compiler/mod.rs
+++ b/compiler/src/compiler/mod.rs
@@ -8,7 +8,7 @@ mod rendering;
 mod result_columns;
 mod scope;
 
-use querydown_parser::ast::AnnotationValue;
+use querydown_parser::ast::{AnnotationValue, Query};
 use querydown_parser::parse;
 use serde::Serialize;
 
@@ -49,13 +49,24 @@ impl Compiler {
         Ok(Self { options, schema })
     }
 
+    /// Compiles Querydown source code into SQL plus column annotations.
     pub fn compile(&self, input: String) -> Result<CompileResult, String> {
-        let query = parse(&input)?;
+        self.compile_query(parse(&input)?)
+    }
+
+    /// Compiles an already-parsed [`Query`] into SQL plus column annotations.
+    ///
+    /// This is the lower-level counterpart to [`Compiler::compile`], which parses source code
+    /// before compiling it. It exists so that a consumer can parse the sections of a query
+    /// independently — via the parser crate's section parsers — reassemble them with
+    /// [`Query::from_parts`], and then compile the result, rather than handing over a single string.
+    pub fn compile_query(&self, query: Query) -> Result<CompileResult, String> {
+        let definitions = query.definitions;
         let mut scope = Scope::build(&self.options, &self.schema, &query.base_table)?;
-        scope.register_constants(query.constants);
-        scope.register_functions(query.functions);
-        scope.register_custom_comparisons(query.custom_comparisons)?;
-        scope.register_computed_columns(query.computed_columns)?;
+        scope.register_constants(definitions.constants);
+        scope.register_functions(definitions.functions);
+        scope.register_custom_comparisons(definitions.custom_comparisons)?;
+        scope.register_computed_columns(definitions.computed_columns)?;
         let mut select = Select::from(scope.get_base_table().name.clone());
 
         let mut transformations_iter = query.transformations.into_iter();

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -9,5 +9,12 @@ mod utils;
 
 pub use compiler::{CompileResult, Compiler};
 pub use options::{IdentifierResolution, Options};
-pub use querydown_parser::ast::AnnotationValue;
 pub use sql::{Dialect, DuckDB, Postgres};
+
+// Re-exported from the parser crate so that consumers of the `querydown` crate can parse Querydown
+// code (in whole or in sections) and inspect or assemble the resulting AST without taking a direct
+// dependency on `querydown-parser`.
+pub use querydown_parser::ast::AnnotationValue;
+pub use querydown_parser::{
+    ast, parse, parse_conditions, parse_definitions, parse_display, parse_sorting,
+};

--- a/compiler/src/tests/definitions.rs
+++ b/compiler/src/tests/definitions.rs
@@ -60,3 +60,28 @@ fn custom_comparison_operator_can_be_switched_when_body_is_all_match() {
     let input = "#issues.commenter:@x = ++#comments{user.username:@x}\n#issues commenter:=alice";
     assert!(compile(input).is_ok());
 }
+
+#[test]
+fn sections_parsed_in_isolation_compile_like_a_whole_query() {
+    // Parsing each section independently and reassembling with `Query::from_parts`, then compiling
+    // via `compile_query`, produces the same SQL as compiling the equivalent whole-query string.
+    use querydown_parser::ast::Query;
+    use querydown_parser::{parse_conditions, parse_definitions, parse_display, parse_sorting};
+
+    let schema_json = get_test_resource("issue_schema.json");
+    let options = build_options(crate::options::IdentifierResolution::Flexible, "postgres");
+    let compiler = Compiler::new(&schema_json, options).unwrap();
+
+    let query = Query::from_parts(
+        "issues".to_string(),
+        parse_definitions("@n = 1234").unwrap(),
+        parse_conditions("author:@n").unwrap(),
+        parse_sorting(r"\\id \d").unwrap(),
+        parse_display("$id $title").unwrap(),
+    );
+    let from_sections = compiler.compile_query(query).unwrap().sql;
+
+    let whole = compile("@n = 1234\n#issues author:@n \\\\id \\d $id $title").unwrap();
+
+    assert_eq!(from_sections, whole);
+}

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -53,6 +53,48 @@ impl Serialize for AnnotationValue {
 
 #[derive(Debug, PartialEq)]
 pub struct Query {
+    /// The definitions (constants, functions, custom comparisons, and computed columns) written
+    /// before the base table.
+    pub definitions: Definitions,
+    pub base_table: String,
+    pub transformations: Vec<Transformation>,
+}
+
+impl Query {
+    /// Assembles a [`Query`] from independently-parsed sections plus a base table.
+    ///
+    /// This is the reassembly counterpart to parsing each section of a query in isolation (see the
+    /// `parse_definitions`, `parse_conditions`, `parse_sorting`, and `parse_display` functions in
+    /// the crate root). It bundles the `conditions`, `sorting`, and `display` sections into a single
+    /// [`Transformation`], which — together with the `definitions` and `base_table` — forms a
+    /// complete query ready to be handed to the compiler.
+    ///
+    /// The base table is supplied separately because it is not part of any of the four sections; in
+    /// a multi-input UI it is typically chosen on its own (e.g. via a dropdown) rather than typed.
+    pub fn from_parts(
+        base_table: String,
+        definitions: Definitions,
+        conditions: ConditionSet,
+        sorting: Vec<SortExpr>,
+        display: Vec<ResultColumnStatement>,
+    ) -> Self {
+        Query {
+            definitions,
+            base_table,
+            transformations: vec![Transformation {
+                conditions,
+                sorting,
+                result_columns: display,
+            }],
+        }
+    }
+}
+
+/// The definitions that may precede a query's base table. Each kind shares the same position in the
+/// source (before the base table) and may be parsed on its own via the crate-root
+/// `parse_definitions` function.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Definitions {
     /// User-defined constant definitions, written as `@name = expr` before the base table. Each
     /// binds a name to an expression whose value is inlined wherever the constant is referenced.
     pub constants: Vec<ConstantDef>,
@@ -67,8 +109,6 @@ pub struct Query {
     /// scoped to a table, which can then be referenced (by name) like a real column elsewhere in the
     /// query — including within the definitions of later computed columns.
     pub computed_columns: Vec<ComputedColumn>,
-    pub base_table: String,
-    pub transformations: Vec<Transformation>,
 }
 
 /// A computed column definition, written as `#table.name = expr` before the query's base table.

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,13 +3,111 @@ mod parser;
 pub mod ast;
 pub mod tokens;
 
-use chumsky::Parser;
-use parser::query;
+use chumsky::prelude::*;
+use parser::{conditions, definitions, pad, query, result_columns, sorting, Psr};
 
+/// Parses a complete Querydown query — definitions, base table, and transformations — into an
+/// [`ast::Query`].
 pub fn parse(input: &str) -> Result<ast::Query, String> {
-    query()
+    run(query(), input)
+}
+
+/// Parses just the definitions section of a query (constants, functions, custom comparisons, and
+/// computed columns) in isolation, without a base table or any transformations.
+///
+/// This is one of four section parsers — alongside [`parse_conditions`], [`parse_sorting`], and
+/// [`parse_display`] — that let a consumer parse each part of a query independently and then
+/// reassemble them via [`ast::Query::from_parts`] before compiling. Parsing the sections separately
+/// keeps them isolated: text entered for one section cannot introduce constructs that belong to
+/// another (e.g. a filtering section cannot smuggle in constant definitions).
+pub fn parse_definitions(input: &str) -> Result<ast::Definitions, String> {
+    run(definitions(), input)
+}
+
+/// Parses just the filtering section of a query in isolation: a whitespace-separated sequence of
+/// boolean expressions, combined with `AND`, into an [`ast::ConditionSet`].
+///
+/// See [`parse_definitions`] for how the section parsers fit together.
+pub fn parse_conditions(input: &str) -> Result<ast::ConditionSet, String> {
+    run(conditions(), input)
+}
+
+/// Parses just the sorting section of a query in isolation: a sequence of standalone `\\` sorting
+/// expressions into a `Vec<`[`ast::SortExpr`]`>`.
+///
+/// See [`parse_definitions`] for how the section parsers fit together.
+pub fn parse_sorting(input: &str) -> Result<Vec<ast::SortExpr>, String> {
+    run(sorting(), input)
+}
+
+/// Parses just the display section of a query in isolation: the `$`-prefixed result column
+/// statements into a `Vec<`[`ast::ResultColumnStatement`]`>`.
+///
+/// See [`parse_definitions`] for how the section parsers fit together.
+pub fn parse_display(input: &str) -> Result<Vec<ast::ResultColumnStatement>, String> {
+    run(result_columns(), input)
+}
+
+/// Runs a parser over the whole of `input`, allowing surrounding whitespace/comments and requiring
+/// that the entire input is consumed.
+fn run<'src, T>(parser: impl Psr<'src, T>, input: &'src str) -> Result<T, String> {
+    pad()
+        .ignore_then(parser)
+        .then_ignore(pad())
+        .then_ignore(end())
         .parse(input)
         .into_result()
         // TODO_ERR improve error handling
         .map_err(|_| "Invalid querydown code".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ast::*;
+    use super::*;
+
+    #[test]
+    fn test_parse_sections_reassemble_into_whole_query() {
+        // Parsing each section in isolation and reassembling via `Query::from_parts` yields the same
+        // AST as parsing the equivalent whole query in one shot.
+        let definitions = parse_definitions("@user_id = 1234").unwrap();
+        let conditions = parse_conditions("author:@user_id").unwrap();
+        let sorting = parse_sorting(r"\\created_at \d").unwrap();
+        let display = parse_display("$id $title").unwrap();
+        let reassembled = Query::from_parts(
+            "issues".to_string(),
+            definitions,
+            conditions,
+            sorting,
+            display,
+        );
+
+        let whole = parse("@user_id = 1234\n#issues author:@user_id \\\\created_at \\d $id $title")
+            .unwrap();
+
+        assert_eq!(reassembled, whole);
+    }
+
+    #[test]
+    fn test_empty_sections_parse_to_empty_results() {
+        assert_eq!(parse_definitions("").unwrap(), Definitions::default());
+        assert_eq!(parse_conditions("").unwrap(), ConditionSet::default());
+        assert_eq!(parse_sorting("").unwrap(), vec![]);
+        assert!(parse_display("").unwrap().is_empty());
+        // Whitespace and comments alone are also empty.
+        assert_eq!(
+            parse_definitions("  // nothing here\n").unwrap(),
+            Definitions::default()
+        );
+    }
+
+    #[test]
+    fn test_sections_are_isolated() {
+        // A constant definition is only valid in the definitions section; it is rejected when fed to
+        // the conditions parser. This isolation is the whole point of the section parsers.
+        assert!(parse_definitions("@user_id = 1234").is_ok());
+        assert!(parse_conditions("@user_id = 1234").is_err());
+        // Likewise, a `$`-prefixed display column is rejected by the conditions parser.
+        assert!(parse_conditions("$id").is_err());
+    }
 }

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -5,4 +5,7 @@ mod query;
 mod sorting;
 mod utils;
 
-pub use query::query;
+pub use column_layout::result_columns;
+pub use query::{conditions, definitions, query};
+pub use sorting::sorting;
+pub(crate) use utils::{pad, Psr};

--- a/parser/src/parser/query.rs
+++ b/parser/src/parser/query.rs
@@ -18,43 +18,47 @@ enum Definition {
 }
 
 pub fn query<'src>() -> impl Psr<'src, Query> {
-    let definitions = definition()
-        .then_ignore(pad())
-        .repeated()
-        .collect::<Vec<Definition>>();
     let base_table = just(TABLE_SIGIL).ignore_then(db_identifier());
     let transformations = transformation()
         .separated_by(pad().then(exactly(TRANSFORMATION_DELIMITER)).then(pad()))
         .collect::<Vec<Transformation>>();
     pad().ignore_then(
-        definitions
+        definitions()
             .then(base_table)
             .then_ignore(pad())
             .then(transformations)
             .then_ignore(pad().then(end()))
-            .map(|((definitions, base_table), transformations)| {
-                let mut constants = vec![];
-                let mut functions = vec![];
-                let mut custom_comparisons = vec![];
-                let mut computed_columns = vec![];
-                for definition in definitions {
-                    match definition {
-                        Definition::Constant(c) => constants.push(c),
-                        Definition::Function(f) => functions.push(f),
-                        Definition::CustomComparison(c) => custom_comparisons.push(c),
-                        Definition::ComputedColumn(c) => computed_columns.push(c),
-                    }
-                }
-                Query {
-                    constants,
-                    functions,
-                    custom_comparisons,
-                    computed_columns,
-                    base_table,
-                    transformations,
-                }
+            .map(|((definitions, base_table), transformations)| Query {
+                definitions,
+                base_table,
+                transformations,
             }),
     )
+}
+
+/// Parses the run of definitions (constants, functions, custom comparisons, and computed columns)
+/// that may precede the base table, sorting them by kind into a [`Definitions`]. Yields an empty
+/// [`Definitions`] when none are present.
+///
+/// This is exposed so that the definitions section of a query can be parsed in isolation, separate
+/// from the base table and transformations.
+pub fn definitions<'src>() -> impl Psr<'src, Definitions> {
+    definition()
+        .then_ignore(pad())
+        .repeated()
+        .collect::<Vec<Definition>>()
+        .map(|definitions| {
+            let mut result = Definitions::default();
+            for definition in definitions {
+                match definition {
+                    Definition::Constant(c) => result.constants.push(c),
+                    Definition::Function(f) => result.functions.push(f),
+                    Definition::CustomComparison(c) => result.custom_comparisons.push(c),
+                    Definition::ComputedColumn(c) => result.computed_columns.push(c),
+                }
+            }
+            result
+        })
 }
 
 /// Parses any of the definitions that may precede the base table.
@@ -164,7 +168,7 @@ fn custom_comparison<'src>() -> impl Psr<'src, CustomComparisonDef> {
 }
 
 fn transformation<'src>() -> impl Psr<'src, Transformation> {
-    top_level_condition_set()
+    conditions()
         .then_ignore(pad())
         .then(sorting())
         .then_ignore(pad())
@@ -176,7 +180,13 @@ fn transformation<'src>() -> impl Psr<'src, Transformation> {
         })
 }
 
-fn top_level_condition_set<'src>() -> impl Psr<'src, ConditionSet> {
+/// Parses the top-level filtering section of a transformation: a whitespace-separated sequence of
+/// boolean expressions, combined with `AND`, yielding a [`ConditionSet`]. Yields an empty
+/// [`ConditionSet`] when no expressions are present.
+///
+/// This is exposed so that the filtering section of a query can be parsed in isolation, separate
+/// from sorting and display.
+pub fn conditions<'src>() -> impl Psr<'src, ConditionSet> {
     expr()
         .padded_by(pad())
         .repeated()
@@ -196,10 +206,7 @@ mod tests {
         assert_eq!(
             query().parse("#foo a:1 b:2 $c").into_result(),
             Ok(Query {
-                constants: vec![],
-                functions: vec![],
-                custom_comparisons: vec![],
-                computed_columns: vec![],
+                definitions: Definitions::default(),
                 base_table: "foo".to_string(),
                 transformations: vec![Transformation {
                     sorting: vec![],
@@ -259,15 +266,21 @@ mod tests {
             .into_result()
             .unwrap();
         assert_eq!(result.base_table, "users".to_string());
-        assert_eq!(result.computed_columns.len(), 2);
-        assert_eq!(result.computed_columns[0].table, "users".to_string());
-        assert_eq!(result.computed_columns[0].name, "age".to_string());
+        assert_eq!(result.definitions.computed_columns.len(), 2);
         assert_eq!(
-            result.computed_columns[1].name,
+            result.definitions.computed_columns[0].table,
+            "users".to_string()
+        );
+        assert_eq!(
+            result.definitions.computed_columns[0].name,
+            "age".to_string()
+        );
+        assert_eq!(
+            result.definitions.computed_columns[1].name,
             "can_purchase_alcohol".to_string()
         );
         assert_eq!(
-            result.computed_columns[1].expr,
+            result.definitions.computed_columns[1].expr,
             Expr::Comparison(Box::new(Comparison {
                 left: ComparisonSide::Expr(Expr::Path(vec![PathPart::Column("age".to_string())])),
                 operator: Operator::Gte,
@@ -285,13 +298,13 @@ mod tests {
             .unwrap();
         assert_eq!(result.base_table, "issues".to_string());
         assert_eq!(
-            result.constants,
+            result.definitions.constants,
             vec![ConstantDef {
                 name: "user_id".to_string(),
                 expr: Expr::Number("1234".to_string()),
             }]
         );
-        assert!(result.computed_columns.is_empty());
+        assert!(result.definitions.computed_columns.is_empty());
     }
 
     #[test]
@@ -302,8 +315,8 @@ mod tests {
             .into_result()
             .unwrap();
         assert_eq!(result.base_table, "issues".to_string());
-        assert_eq!(result.functions.len(), 1);
-        let func = &result.functions[0];
+        assert_eq!(result.definitions.functions.len(), 1);
+        let func = &result.definitions.functions[0];
         assert_eq!(func.name, "double".to_string());
         assert_eq!(func.params, vec!["x".to_string()]);
         assert!(func.body.assignments.is_empty());
@@ -323,7 +336,7 @@ mod tests {
             .parse("@@f = @a @b =>\n  @s = @a + @b\n  @s * 2\n#issues $id|f(2 3)")
             .into_result()
             .unwrap();
-        let func = &result.functions[0];
+        let func = &result.definitions.functions[0];
         assert_eq!(func.name, "f".to_string());
         assert_eq!(func.params, vec!["a".to_string(), "b".to_string()]);
         assert_eq!(func.body.assignments.len(), 1);
@@ -351,8 +364,8 @@ mod tests {
             .into_result()
             .unwrap();
         assert_eq!(result.base_table, "issues".to_string());
-        assert_eq!(result.custom_comparisons.len(), 1);
-        let def = &result.custom_comparisons[0];
+        assert_eq!(result.definitions.custom_comparisons.len(), 1);
+        let def = &result.definitions.custom_comparisons[0];
         assert_eq!(def.table, "issues".to_string());
         assert_eq!(def.name, "comment".to_string());
         assert_eq!(def.operator, Operator::Match);


### PR DESCRIPTION
## Summary

Until now the public `querydown` API only let consumers translate a whole string of Querydown into SQL (`Compiler::compile`). This PR adds lower-level, **section-by-section** parsing so a Rust application can parse each part of a query in isolation and reassemble the parts before compiling.

This supports a UI with separate text inputs for **definitions**, **filtering conditions**, **sorting criteria**, and **display** — keeping each section isolated so that, for example, a filtering input cannot smuggle in constant definitions and a sorting input cannot mangle the display.

## What's new

**Parser crate (`querydown-parser`)**
- Four section parsers, each consuming its entire input:
  - `parse_definitions` → `ast::Definitions` (constants, functions, custom comparisons, computed columns)
  - `parse_conditions` → `ast::ConditionSet`
  - `parse_sorting` → `Vec<ast::SortExpr>`
  - `parse_display` → `Vec<ast::ResultColumnStatement>`
- New `ast::Definitions` struct, now embedded in `ast::Query` (replacing the four loose definition fields).
- `ast::Query::from_parts(base_table, definitions, conditions, sorting, display)` to reassemble parsed sections — plus a separately-supplied base table — into a complete query.

**Compiler crate (`querydown`)**
- `Compiler::compile_query(query: ast::Query)` compiles an already-parsed `Query`. `Compiler::compile(String)` now parses, then delegates to it.
- Re-exports the four section parsers and the `ast` module from the `querydown` crate root, so consumers don't need a direct dependency on `querydown-parser`.

## Typical consumer usage

```rust
use querydown::{ast::Query, parse_conditions, parse_definitions, parse_display, parse_sorting, Compiler};

let query = Query::from_parts(
    base_table,                                  // chosen separately (e.g. a dropdown)
    parse_definitions(&definitions_input)?,
    parse_conditions(&filter_input)?,
    parse_sorting(&sorting_input)?,
    parse_display(&display_input)?,
);
let result = compiler.compile_query(query)?;
```

## Notes

- The base table is supplied as its own argument to `from_parts` rather than being one of the four sections, since in a multi-input UI it's naturally selected on its own.
- All four public APIs are documented with doc comments.

## Testing

- `cargo check`, `cargo clippy`, `cargo build`, `cargo test`, `cargo fmt` all pass.
- Added parser tests (section reassembly equals whole-query parse; empty sections; cross-section rejection) and a compiler test (compiling reassembled sections yields identical SQL to the equivalent whole-query string).
- `cargo test --features db-tests`: the only failure is the postgres-dependent corpus test, which needs the `initdb` binary not present outside the dev container — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hXisyDLk68FbmiK6tqmgF

---
_Generated by [Claude Code](https://claude.ai/code/session_019hXisyDLk68FbmiK6tqmgF)_