### PR TITLE
Implement function calling and anonymous functions

### DIFF
--- a/compiler/src/compiler/comparisons.rs
+++ b/compiler/src/compiler/comparisons.rs
@@ -458,6 +458,11 @@ fn expr_all_match(expr: &Expr) -> bool {
                 && w.partition_by.iter().all(expr_all_match)
                 && w.order_by.iter().all(|s| expr_all_match(&s.expr))
         }
+        Expr::AnonymousFunctionCall(c) => {
+            c.args.iter().all(expr_all_match)
+                && c.body.assignments.iter().all(|a| expr_all_match(&a.expr))
+                && expr_all_match(&c.body.expr)
+        }
         Expr::Number(_)
         | Expr::Date(_)
         | Expr::Duration(_)
@@ -529,6 +534,16 @@ fn rewrite_match_operator(expr: &mut Expr, new_operator: Operator) {
             w.order_by
                 .iter_mut()
                 .for_each(|s| rewrite_match_operator(&mut s.expr, new_operator));
+        }
+        Expr::AnonymousFunctionCall(c) => {
+            c.args
+                .iter_mut()
+                .for_each(|e| rewrite_match_operator(e, new_operator));
+            c.body
+                .assignments
+                .iter_mut()
+                .for_each(|a| rewrite_match_operator(&mut a.expr, new_operator));
+            rewrite_match_operator(&mut c.body.expr, new_operator);
         }
         Expr::Number(_)
         | Expr::Date(_)

--- a/compiler/src/compiler/expr.rs
+++ b/compiler/src/compiler/expr.rs
@@ -12,7 +12,7 @@ use super::{
     constants::{
         DEFAULT_TEXT_SEARCH_COMPARISON_NAME, VAR_FALSE, VAR_INFINITY, VAR_NOW, VAR_NULL, VAR_TRUE,
     },
-    functions::convert_call,
+    functions::{convert_anonymous_function_call, convert_call},
     paths::{clarify_path, ClarifiedPathTail},
     scope::Scope,
 };
@@ -49,6 +49,7 @@ pub fn convert_expr(expr: Expr, scope: &mut Scope) -> Result<SqlExpr, String> {
         Expr::Comparison(c) => convert_comparison(*c, scope),
         Expr::Not(e) => Ok(cond::not(convert_expr(*e, scope)?)),
         Expr::Window(w) => super::window::convert_window(w, scope),
+        Expr::AnonymousFunctionCall(c) => convert_anonymous_function_call(*c, scope),
     }
 }
 

--- a/compiler/src/compiler/functions.rs
+++ b/compiler/src/compiler/functions.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use querydown_parser::ast::{Call, Expr, FunctionDef, FunctionDimension, SortExpr};
+use querydown_parser::ast::{
+    AnonymousFunctionCall, Assignment, Call, Expr, FunctionBody, FunctionDef, FunctionDimension,
+    SortExpr,
+};
 
 use crate::{
     compiler::{
@@ -47,20 +50,45 @@ fn convert_user_function_call(
     args: Vec<Expr>,
     scope: &mut Scope,
 ) -> Result<SqlExpr, String> {
-    if args.len() != def.params.len() {
+    apply_function(&def.name, def.params, def.body, args, scope)
+}
+
+/// Applies an inline anonymous function (e.g. `value|(@d => @d:<0)`). This works exactly like
+/// applying a user-defined function: the parameters are bound to the arguments and the body is
+/// inlined. The only difference is that an anonymous function has no name.
+pub fn convert_anonymous_function_call(
+    call: AnonymousFunctionCall,
+    scope: &mut Scope,
+) -> Result<SqlExpr, String> {
+    apply_function("(anonymous)", call.params, call.body, call.args, scope)
+}
+
+/// Shared logic for applying a function (named or anonymous): bind its parameters to the arguments
+/// and its local assignments, then compile its body expression.
+fn apply_function(
+    name: &str,
+    params: Vec<String>,
+    body: FunctionBody,
+    args: Vec<Expr>,
+    scope: &mut Scope,
+) -> Result<SqlExpr, String> {
+    if args.len() != params.len() {
         return Err(msg::function_wrong_arg_count(
-            &def.name,
-            def.params.len(),
+            name,
+            params.len(),
             args.len(),
         ));
     }
-    let bindings: Vec<(String, Expr)> = def
-        .params
+    let bindings: Vec<(String, Expr)> = params
         .into_iter()
         .zip(args)
-        .chain(def.body.assignments.into_iter().map(|a| (a.name, a.expr)))
+        .chain(
+            body.assignments
+                .into_iter()
+                .map(|a: Assignment| (a.name, a.expr)),
+        )
         .collect();
-    scope.with_variable_bindings(bindings, |scope| convert_expr(def.body.expr, scope))
+    scope.with_variable_bindings(bindings, |scope| convert_expr(body.expr, scope))
 }
 
 fn convert_aggregate_call(

--- a/compiler/src/compiler/result_columns.rs
+++ b/compiler/src/compiler/result_columns.rs
@@ -80,6 +80,15 @@ fn contains_aggregate(expr: &Expr) -> bool {
         // requirement. Combining `\g` grouping with a window function in the same stage is not
         // supported; use a pipeline (`~~~`) to group the output of a window stage.
         Expr::Window(_) => false,
+        // An anonymous function aggregates if any of its arguments or its body do.
+        Expr::AnonymousFunctionCall(c) => {
+            c.args.iter().any(contains_aggregate)
+                || c.body
+                    .assignments
+                    .iter()
+                    .any(|a| contains_aggregate(&a.expr))
+                || contains_aggregate(&c.body.expr)
+        }
         Expr::Number(_)
         | Expr::Date(_)
         | Expr::Duration(_)

--- a/compiler/src/compiler/window.rs
+++ b/compiler/src/compiler/window.rs
@@ -125,6 +125,14 @@ pub fn expr_contains_window(expr: &Expr) -> bool {
         }
         Expr::ConditionSet(cs) => cs.entries.iter().any(expr_contains_window),
         Expr::Comparison(c) => side_contains_window(&c.left) || side_contains_window(&c.right),
+        Expr::AnonymousFunctionCall(c) => {
+            c.args.iter().any(expr_contains_window)
+                || c.body
+                    .assignments
+                    .iter()
+                    .any(|a| expr_contains_window(&a.expr))
+                || expr_contains_window(&c.body.expr)
+        }
         Expr::Number(_)
         | Expr::Date(_)
         | Expr::Duration(_)

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -2169,6 +2169,139 @@ WHERE
   FLOOR(EXTRACT(epoch FROM NOW() - "users"."birth_date") / 31557600) >= 21;
 ```
 
+## Anonymous functions
+
+### Basic anonymous function
+
+> Categorize each issue by how soon it is due. The piped-in value is bound to the anonymous
+> function's `@d` parameter, and the body is inlined wherever `@d` is referenced.
+
+```qd
+#issues
+$title
+$due_date|countdown|days|(@d => ? @d:<0 ~ "overdue" @d:<30 ~ "due soon" ~~ "due later")
+```
+
+```sql
+SELECT
+  "issues"."title",
+  CASE
+    WHEN EXTRACT(epoch FROM "issues"."due_date" - NOW()) / 86400 < 0 THEN 'overdue'
+    WHEN EXTRACT(epoch FROM "issues"."due_date" - NOW()) / 86400 < 30 THEN 'due soon'
+    ELSE 'due later'
+  END
+FROM "issues";
+```
+
+### Anonymous function with a simple body
+
+> An anonymous function's body can be any expression. Here the piped-in `id` is doubled.
+
+```qd
+#issues $id|(@x => @x * 2)
+```
+
+```sql
+SELECT
+  "issues"."id" * 2
+FROM "issues";
+```
+
+### Anonymous function used within a condition
+
+> An anonymous function may be applied anywhere an expression is allowed, including conditions.
+
+```qd
+#issues id|(@x => @x * 10):>0 $title
+```
+
+```sql
+SELECT
+  "issues"."title"
+FROM "issues"
+WHERE
+  "issues"."id" * 10 > 0;
+```
+
+### Anonymous function with a local assignment and extra argument
+
+> Like a user-defined function, an anonymous function may take more than one parameter (the piped-in
+> value plus parenthesized arguments) and may contain local assignments before its result.
+
+```qd
+#issues $id|(@a @b => @s = @a + @b @s * 2)(100)
+```
+
+```sql
+SELECT
+  ("issues"."id" + 100) * 2
+FROM "issues";
+```
+
+## Function calling
+
+### Basic function call
+
+> Use `@@` to call a function without a pipe. For each issue, show how many days it is overdue,
+> displaying zero instead of negative numbers. Arguments are separated by spaces, not commas.
+
+```qd
+#issues $title $@@max(due_date|age|days 0)
+```
+
+```sql
+SELECT
+  "issues"."title",
+  GREATEST(EXTRACT(epoch FROM NOW() - "issues"."due_date") / 86400, 0)
+FROM "issues";
+```
+
+### Function call equivalent to a pipe
+
+> The direct call above is equivalent to applying the same function via a pipe.
+
+```qd
+#issues $title $due_date|age|days|max(0)
+```
+
+```sql
+SELECT
+  "issues"."title",
+  GREATEST(EXTRACT(epoch FROM NOW() - "issues"."due_date") / 86400, 0)
+FROM "issues";
+```
+
+### Function call on a user-defined function
+
+> The `@@` call syntax works with user-defined functions too.
+
+```qd
+@@add = @a @b => @a + @b
+#issues $@@add(id 100)
+```
+
+```sql
+SELECT
+  "issues"."id" + 100
+FROM "issues";
+```
+
+### Function call used within a condition
+
+> A direct call may appear anywhere an expression is allowed, including conditions.
+
+```qd
+#issues @@max(id 0):>5 $title
+```
+
+```sql
+SELECT
+  "issues"."title"
+FROM "issues"
+WHERE
+  GREATEST("issues"."id", 0) > 5;
+```
+
 ## Custom comparisons
 
 ### Basic custom comparison

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -117,9 +117,9 @@ See [case expressions](./language.md#case-expressions) docs.
 | `+` `-` `*` `/` | basic arithmetic operators | ✅ |
 | <tt>&VerticalLine;</tt> | [pipe a value into a scalar function](./language.md#function-piping) | ✅ |
 | `%` | pipe a value to an aggregate function | ✅ |
-| `@@` | [call a scalar function without piping](./language.md#function-calling) | ❌ |
+| `@@` | [call a scalar function without piping](./language.md#function-calling) | ✅ |
 | `%%( )` | [window definition](./language.md#window-functions) | ✅ |
-| `=>` | [anonymous scalar function](./language.md#anonymous-functions) | ❌ |
+| `=>` | [anonymous scalar function](./language.md#anonymous-functions) | ✅ |
 
 ## Variables
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -250,8 +250,6 @@ $ ?
 
 ### Anonymous functions
 
-_(🚧 Not yet implemented)_
-
 > Categorize each issue into being either "overdue", "due soon", or "due later".
 
 ```qd
@@ -272,8 +270,6 @@ In the code above:
 1. The body of the anonymous function can reference `@d` as the number of days until the issues due date, using the same value in multiple places with minimal repetition.
 
 ### Function calling
-
-_(🚧 Not yet implemented)_
 
 Use `@@` to call a function without using a pipe.
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -210,6 +210,24 @@ pub enum Expr {
     /// A window function application, written as `%%( ... )%func(args)`. The `%%( ... )` defines the
     /// window (partition and ordering), and the trailing `%func` applies a window function over it.
     Window(WindowFn),
+    /// An anonymous function applied to arguments, e.g. `value|(@d => @d:<0)`. Anonymous functions
+    /// can only be applied immediately, via a pipe, so this node always carries its arguments. Like
+    /// a user-defined function, its parameters are bound to the arguments and its body is inlined.
+    AnonymousFunctionCall(Box<AnonymousFunctionCall>),
+}
+
+/// An anonymous function applied to arguments, written as `value|(@param => body)`. The piped-in
+/// value becomes the first argument. There is no way to name or store an anonymous function, so it
+/// is always applied at the point where it is written.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnonymousFunctionCall {
+    /// Parameter names, without the `@` sigil, in order.
+    pub params: Vec<String>,
+    /// The function body: zero or more local assignments followed by a single result expression.
+    pub body: FunctionBody,
+    /// The arguments to which the function is applied. The first is the piped-in value; any others
+    /// come from parenthesized arguments following the anonymous function.
+    pub args: Vec<Expr>,
 }
 
 /// A window function application: a function applied over a window defined by partition and ordering

--- a/parser/src/parser/expr/mod.rs
+++ b/parser/src/parser/expr/mod.rs
@@ -60,6 +60,9 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
             number().map(Expr::Number),
             date().map(Expr::Date),
             string().map(Expr::String),
+            // `function_call` is tried before `variable` because both begin with `@`; the `@@`
+            // prefix of a call would otherwise be misread as the start of a `@`-prefixed variable.
+            function_call(prec_comma.clone()),
             variable().map(Expr::Variable),
             window(prec_comma.clone()),
             path(prec_comma.clone()).map(Expr::Path),
@@ -86,6 +89,8 @@ pub fn expr<'src>() -> impl Psr<'src, Expr> {
             number().map(Expr::Number),
             date().map(Expr::Date),
             string().map(Expr::String),
+            // See the ordering note on `prec_atom` above: `function_call` before `variable`.
+            function_call(prec_comma.clone()),
             variable().map(Expr::Variable),
             comparison_rhs_value(prec_comma.clone()),
             has_quantity(prec_comma.clone()).map(Expr::HasQuantity),
@@ -201,6 +206,33 @@ fn operator<'src>(
 
 fn variable<'src>() -> impl Psr<'src, String> {
     just(CONST_SIGIL).ignore_then(ident().map(|s: &str| s.to_string()))
+}
+
+/// Parses a direct function call, written with the `@@` sigil, e.g. `@@max(due_date|age|days 0)`.
+/// This applies a (built-in or user-defined) scalar function without using a pipe. The arguments are
+/// space-separated (no commas) and enclosed in parentheses; the parentheses are required even for a
+/// call with no arguments.
+fn function_call<'src>(args_expr: impl Psr<'src, Expr>) -> impl Psr<'src, Expr> {
+    let args = args_expr
+        .padded_by(pad())
+        .repeated()
+        .collect::<Vec<Expr>>()
+        .delimited_by(
+            just(COMPOSITION_ARGUMENT_BRACE_L),
+            just(COMPOSITION_ARGUMENT_BRACE_R),
+        );
+    exactly(FUNCTION_SIGIL)
+        .ignore_then(ident().map(|s: &str| s.to_string()))
+        .then(args)
+        .map(|(name, args)| {
+            Expr::Call(Call {
+                name,
+                dimension: FunctionDimension::Scalar,
+                syntax: CallSyntax::Standalone,
+                args,
+                order_by: vec![],
+            })
+        })
 }
 
 fn string<'src>() -> impl Psr<'src, String> {
@@ -685,6 +717,124 @@ mod tests {
                     })),
                 ]
             }))
+        );
+    }
+
+    #[test]
+    fn test_parse_function_call() {
+        let p = |s: &str| {
+            expr()
+                .then_ignore(end())
+                .parse(s)
+                .into_result()
+                .map_err(|_| ())
+        };
+
+        // A direct function call with `@@`: scalar dimension, standalone syntax, space-separated
+        // arguments (no commas).
+        assert_eq!(
+            p("@@max(foo 0)"),
+            Ok(Expr::Call(Call {
+                name: "max".to_string(),
+                dimension: FunctionDimension::Scalar,
+                syntax: CallSyntax::Standalone,
+                args: vec![
+                    Expr::Path(vec![PathPart::Column("foo".to_string())]),
+                    Expr::Number("0".to_string()),
+                ],
+                order_by: vec![],
+            }))
+        );
+
+        // The parentheses are required, but may be empty for a no-argument call.
+        assert_eq!(
+            p("@@now()"),
+            Ok(Expr::Call(Call {
+                name: "now".to_string(),
+                dimension: FunctionDimension::Scalar,
+                syntax: CallSyntax::Standalone,
+                args: vec![],
+                order_by: vec![],
+            }))
+        );
+
+        // Arguments may themselves be pipes.
+        assert_eq!(
+            p("@@max(foo|bar 0)"),
+            Ok(Expr::Call(Call {
+                name: "max".to_string(),
+                dimension: FunctionDimension::Scalar,
+                syntax: CallSyntax::Standalone,
+                args: vec![
+                    Expr::Call(Call {
+                        name: "bar".to_string(),
+                        dimension: FunctionDimension::Scalar,
+                        syntax: CallSyntax::Piped,
+                        args: vec![Expr::Path(vec![PathPart::Column("foo".to_string())])],
+                        order_by: vec![],
+                    }),
+                    Expr::Number("0".to_string()),
+                ],
+                order_by: vec![],
+            }))
+        );
+    }
+
+    #[test]
+    fn test_parse_anonymous_function() {
+        let p = |s: &str| {
+            expr()
+                .then_ignore(end())
+                .parse(s)
+                .into_result()
+                .map_err(|_| ())
+        };
+
+        // An anonymous function applied via a pipe. The piped-in value becomes the sole argument,
+        // and the body references the parameter.
+        assert_eq!(
+            p("foo|(@x => @x * 2)"),
+            Ok(Expr::AnonymousFunctionCall(Box::new(
+                AnonymousFunctionCall {
+                    params: vec!["x".to_string()],
+                    body: FunctionBody {
+                        assignments: vec![],
+                        expr: Expr::Product(
+                            Box::new(Expr::Variable("x".to_string())),
+                            Box::new(Expr::Number("2".to_string())),
+                        ),
+                    },
+                    args: vec![Expr::Path(vec![PathPart::Column("foo".to_string())])],
+                }
+            )))
+        );
+
+        // An anonymous function may take multiple parameters and contain a local assignment. The
+        // piped-in value is the first argument; parenthesized values supply the rest.
+        assert_eq!(
+            p("foo|(@a @b => @s = @a + @b @s * 2)(3)"),
+            Ok(Expr::AnonymousFunctionCall(Box::new(
+                AnonymousFunctionCall {
+                    params: vec!["a".to_string(), "b".to_string()],
+                    body: FunctionBody {
+                        assignments: vec![Assignment {
+                            name: "s".to_string(),
+                            expr: Expr::Sum(
+                                Box::new(Expr::Variable("a".to_string())),
+                                Box::new(Expr::Variable("b".to_string())),
+                            ),
+                        }],
+                        expr: Expr::Product(
+                            Box::new(Expr::Variable("s".to_string())),
+                            Box::new(Expr::Number("2".to_string())),
+                        ),
+                    },
+                    args: vec![
+                        Expr::Path(vec![PathPart::Column("foo".to_string())]),
+                        Expr::Number("3".to_string()),
+                    ],
+                }
+            )))
         );
     }
 

--- a/parser/src/parser/expr/pipe.rs
+++ b/parser/src/parser/expr/pipe.rs
@@ -34,6 +34,55 @@ fn aggregate_order_by<'src>(args_expr: impl Psr<'src, Expr>) -> impl Psr<'src, V
         .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R))
 }
 
+/// One step in a pipe chain: a function applied to the value accumulated so far. Either a named
+/// (built-in or user-defined) function or an inline anonymous function.
+enum PipeStep {
+    Call {
+        dimension: FunctionDimension,
+        name: String,
+        extra_args: Vec<Expr>,
+        order_by: Vec<SortExpr>,
+    },
+    AnonymousFn {
+        params: Vec<String>,
+        body: FunctionBody,
+        extra_args: Vec<Expr>,
+    },
+}
+
+/// Parses an inline anonymous function, e.g. `(@d => ? @d:<0 ~ "a" ~~ "b")`. The body — like a
+/// user-defined function's body — is zero or more local assignments followed by a single result
+/// expression, and may reference the parameters and earlier assignments.
+fn anonymous_function<'src>(
+    body_expr: impl Psr<'src, Expr>,
+) -> impl Psr<'src, (Vec<String>, FunctionBody)> {
+    let params = super::variable()
+        .separated_by(pad())
+        .at_least(1)
+        .collect::<Vec<String>>();
+    // A local assignment, distinguished from the result expression by the `=` that follows its name.
+    // The `=` must not begin a `=>` arrow (defensive; arrows only appear in the parameter list).
+    let assignment = super::variable()
+        .then_ignore(pad())
+        .then_ignore(just(DEFINITION_ASSIGN).then_ignore(just('>').not()))
+        .then_ignore(pad())
+        .then(body_expr.clone())
+        .map(|(name, expr)| Assignment { name, expr });
+    let function_body = assignment
+        .then_ignore(pad())
+        .repeated()
+        .collect::<Vec<Assignment>>()
+        .then(body_expr)
+        .map(|(assignments, expr)| FunctionBody { assignments, expr });
+    params
+        .then_ignore(pad().then(exactly(FUNCTION_ARROW)).then(pad()))
+        .then(function_body)
+        .delimited_by(
+            just(EXPR_PAREN_L).then(pad()),
+            pad().then(just(EXPR_PAREN_R)),
+        )
+}
+
 pub fn pipe<'src>(
     arg0_expr: impl Psr<'src, Expr>,
     extra_args_expr: impl Psr<'src, Expr>,
@@ -48,30 +97,38 @@ pub fn pipe<'src>(
         )
         .then_ignore(just(COMPOSITION_ARGUMENT_BRACE_R));
 
+    // An inline anonymous function applied via a pipe, e.g. `value|(@d => @d:<0)`. The piped-in
+    // value becomes the first argument; any parenthesized values that follow supply the rest.
+    let anonymous_call = just(COMPOSITION_PIPE_SCALAR)
+        .padded_by(pad())
+        .ignore_then(anonymous_function(extra_args_expr.clone()))
+        .then(scalar_args.clone().or_not())
+        .map(|((params, body), extra_args)| PipeStep::AnonymousFn {
+            params,
+            body,
+            extra_args: extra_args.unwrap_or_default(),
+        });
+
     let scalar_call = just(COMPOSITION_PIPE_SCALAR)
         .padded_by(pad())
         .ignore_then(ident())
         .then(scalar_args.or_not())
-        .map(|(name, extra_args)| {
-            (
-                FunctionDimension::Scalar,
-                name.to_string(),
-                extra_args.unwrap_or_default(),
-                vec![],
-            )
+        .map(|(name, extra_args)| PipeStep::Call {
+            dimension: FunctionDimension::Scalar,
+            name: name.to_string(),
+            extra_args: extra_args.unwrap_or_default(),
+            order_by: vec![],
         });
 
     let aggregate_call = just(COMPOSITION_PIPE_AGGREGATE)
         .padded_by(pad())
         .ignore_then(ident())
         .then(aggregate_order_by(extra_args_expr.clone()).or_not())
-        .map(|(name, order_by)| {
-            (
-                FunctionDimension::Aggregate,
-                name.to_string(),
-                vec![],
-                order_by.unwrap_or_default(),
-            )
+        .map(|(name, order_by)| PipeStep::Call {
+            dimension: FunctionDimension::Aggregate,
+            name: name.to_string(),
+            extra_args: vec![],
+            order_by: order_by.unwrap_or_default(),
         });
 
     // A standalone (leading) aggregate, e.g. `%count`, which has no `arg0` to its left. This is how
@@ -91,17 +148,34 @@ pub fn pipe<'src>(
             })
         });
 
+    // `anonymous_call` is tried before `scalar_call` because both begin with `|`; they diverge only
+    // after the pipe (`(` for an anonymous function versus an identifier for a named function).
     choice((leading_aggregate, arg0_expr)).foldl(
-        choice((scalar_call, aggregate_call)).repeated(),
-        |arg0, (dimension, name, extra_args, order_by)| {
-            let args = std::iter::once(arg0).chain(extra_args).collect();
-            Expr::Call(Call {
-                name,
+        choice((anonymous_call, scalar_call, aggregate_call)).repeated(),
+        |arg0, step| match step {
+            PipeStep::Call {
                 dimension,
-                syntax: CallSyntax::Piped,
-                args,
+                name,
+                extra_args,
                 order_by,
-            })
+            } => {
+                let args = std::iter::once(arg0).chain(extra_args).collect();
+                Expr::Call(Call {
+                    name,
+                    dimension,
+                    syntax: CallSyntax::Piped,
+                    args,
+                    order_by,
+                })
+            }
+            PipeStep::AnonymousFn {
+                params,
+                body,
+                extra_args,
+            } => {
+                let args = std::iter::once(arg0).chain(extra_args).collect();
+                Expr::AnonymousFunctionCall(Box::new(AnonymousFunctionCall { params, body, args }))
+            }
         },
     )
 }


### PR DESCRIPTION
## Summary

Implements the two remaining computation features from the language guide, both previously marked _🚧 Not yet implemented_:

### Function calling (`@@`)
A direct, pipe-free scalar function call whose space-separated arguments are enclosed in parentheses:

```qd
#issues $title $@@max(due_date|age|days 0)
```

This is parsed as a standalone scalar `Call`, which the compiler already handles identically to a piped call. It works with built-in and user-defined functions alike.

### Anonymous functions
An inline lambda applied via a pipe. The piped-in value (plus any trailing parenthesized arguments) binds to the parameters, and the body — which may contain local assignments — is inlined, reusing the exact same machinery as user-defined functions:

```qd
#issues $due_date|countdown|days|(@d => ? @d:<0 ~ "overdue" @d:<30 ~ "due soon" ~~ "due later")
```

## Implementation notes
- New AST node `Expr::AnonymousFunctionCall`; `@@` calls reuse the existing `Expr::Call` with `CallSyntax::Standalone`.
- `convert_user_function_call` and the new `convert_anonymous_function_call` now share an `apply_function` helper for parameter binding + body inlining.
- The new variant is handled in every exhaustive `Expr` match (`contains_aggregate`, `expr_all_match`, `rewrite_match_operator`, `expr_contains_window`).

## Tests & docs
- Added parser unit tests for both features.
- Added corpus tests (SQL generation) covering basic use, condition use, multi-param/assignment bodies, user-defined functions, and pipe equivalence.
- Marked both features complete in `docs/language.md` and `docs/cheat-sheet.md`.

## Validation
`cargo check`, `cargo clippy`, `cargo test`, and `cargo fmt` all pass. The `db-tests` suite was not run here because the `postgres`/`duckdb` binaries are not present in this environment (provided by the dev container); the generated SQL is validated by the string-comparison corpus test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYrvH57a3Hkb7uCcaPPeM9)_