### PR TITLE
Coalesce related-record counts to zero

### DIFF
--- a/compiler/src/compiler/functions.rs
+++ b/compiler/src/compiler/functions.rs
@@ -214,6 +214,7 @@ fn agg_1(
     order_by: Vec<SortExpr>,
     scope: &mut Scope,
     agg_wrapper: AggWrapper,
+    coalesce_to_zero: bool,
 ) -> Result<SqlExpr, String> {
     let arg0 = iter_one(args).ok_or_else(msg::expected_one_arg)?;
     let Expr::Path(path_parts) = arg0 else {
@@ -228,7 +229,7 @@ fn agg_1(
                 return Err(msg::aggregate_fn_applied_to_a_path_without_a_column());
             };
             let aggregate_expr_template =
-                AggregateExprTemplate::new(column_name, agg_wrapper, order_by);
+                AggregateExprTemplate::new(column_name, agg_wrapper, order_by, coalesce_to_zero);
             scope.join_chain_to_many(
                 &head,
                 chain_to_many,
@@ -260,16 +261,16 @@ pub fn get_standard_aggregate_functions() -> AggregateFuncMap {
     // between dialects.
     #[rustfmt::skip]
     let templates: [(&str, AggregateFunc); 10] = [
-        ("all_true", |e, ob, s| agg_1(e, ob, s, |a, ob, _| bool_and(a, ob))),
-        ("any_true", |e, ob, s| agg_1(e, ob, s, |a, ob, _| bool_or(a, ob))),
-        ("avg",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| avg(a, ob))),
-        ("count",    |e, ob, s| agg_1(e, ob, s, |a, ob, _| count(a, ob))),
-        ("distinct", |e, ob, s| agg_1(e, ob, s, |a, ob, _| count_distinct(a, ob))),
-        ("list",     |e, ob, s| agg_1(e, ob, s, |a, ob, _| array_agg(a, ob))),
-        ("max",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| max(a, ob))),
-        ("min",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| min(a, ob))),
-        ("product",  |e, ob, s| agg_1(e, ob, s, |a, _ob, d| d.aggregate_product(a))),
-        ("sum",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| sum(a, ob))),
+        ("all_true", |e, ob, s| agg_1(e, ob, s, |a, ob, _| bool_and(a, ob), false)),
+        ("any_true", |e, ob, s| agg_1(e, ob, s, |a, ob, _| bool_or(a, ob), false)),
+        ("avg",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| avg(a, ob), false)),
+        ("count",    |e, ob, s| agg_1(e, ob, s, |a, ob, _| count(a, ob), true)),
+        ("distinct", |e, ob, s| agg_1(e, ob, s, |a, ob, _| count_distinct(a, ob), true)),
+        ("list",     |e, ob, s| agg_1(e, ob, s, |a, ob, _| array_agg(a, ob), false)),
+        ("max",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| max(a, ob), false)),
+        ("min",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| min(a, ob), false)),
+        ("product",  |e, ob, s| agg_1(e, ob, s, |a, _ob, d| d.aggregate_product(a), false)),
+        ("sum",      |e, ob, s| agg_1(e, ob, s, |a, ob, _| sum(a, ob), false)),
     ];
     templates
         .into_iter()

--- a/compiler/src/compiler/paths/ctes.rs
+++ b/compiler/src/compiler/paths/ctes.rs
@@ -28,6 +28,10 @@ pub type AggWrapper = fn(SqlExpr, String, &dyn Dialect) -> SqlExpr;
 pub struct ValueViaCte {
     pub select: Select,
     pub value_alias: String,
+    /// True when the CTE's value is a count, which should be coalesced to zero in the outer query.
+    /// Because the CTE is joined via a LEFT JOIN, base-table rows with no related records produce a
+    /// NULL value. For counts we want those rows to show `0` instead.
+    pub coalesce_to_zero: bool,
 }
 
 pub struct AggregateExprTemplate {
@@ -43,14 +47,23 @@ pub struct AggregateExprTemplate {
     /// expression along with the compiled ORDER BY string.
     agg_wrapper: AggWrapper,
     order_by: Vec<SortExpr>,
+    /// True when this aggregate produces a count (e.g. `count` or `distinct`), so that its value is
+    /// coalesced to zero in the outer query.
+    coalesce_to_zero: bool,
 }
 
 impl AggregateExprTemplate {
-    pub fn new(column_name: String, agg_wrapper: AggWrapper, order_by: Vec<SortExpr>) -> Self {
+    pub fn new(
+        column_name: String,
+        agg_wrapper: AggWrapper,
+        order_by: Vec<SortExpr>,
+        coalesce_to_zero: bool,
+    ) -> Self {
         Self {
             column_name,
             agg_wrapper,
             order_by,
+            coalesce_to_zero,
         }
     }
 }
@@ -130,8 +143,11 @@ pub fn build_cte_select(
     select.ctes.extend(cte_ctes);
 
     if purpose == CtePurpose::AggregateValue {
+        // A bare to-many path with no aggregate template is a plain count of related records.
+        let mut coalesce_to_zero = aggregate_expr_template_opt.is_none();
         let value_expr = match aggregate_expr_template_opt {
             Some(template) => {
+                coalesce_to_zero = template.coalesce_to_zero;
                 let column_name = template.column_name;
                 let column_id = cte_scope
                     .options
@@ -159,10 +175,12 @@ pub fn build_cte_select(
         return Ok(ValueViaCte {
             select,
             value_alias,
+            coalesce_to_zero,
         });
     }
     Ok(ValueViaCte {
         select,
         value_alias: CTE_PK_COLUMN_ALIAS.to_owned(),
+        coalesce_to_zero: false,
     })
 }

--- a/compiler/src/compiler/scope.rs
+++ b/compiler/src/compiler/scope.rs
@@ -11,6 +11,7 @@ use crate::{
         links::{FilteredLink, Link, LinkToOne},
         Schema, Table,
     },
+    sql::expr::build,
     sql::tree::{Cte, CtePurpose, Join, SqlExpr},
     Options,
 };
@@ -328,6 +329,7 @@ impl<'a, 'b> Scope<'a, 'b> {
         let ValueViaCte {
             select,
             value_alias,
+            coalesce_to_zero,
         } = build_cte_select(chain, aggregate_expr_template_opt, self, purpose)?;
         let cte_alias = self.get_cte_alias();
         let cte = Cte {
@@ -336,7 +338,14 @@ impl<'a, 'b> Scope<'a, 'b> {
             join_column_name: starting_column.name.clone(),
         };
         self.integrate_chain(head.as_ref(), Some(cte));
-        Ok(self.table_column_expr(&cte_alias, &value_alias))
+        let reference = self.table_column_expr(&cte_alias, &value_alias);
+        // The CTE is joined via a LEFT JOIN, so base rows with no related records yield NULL. For
+        // counts we coalesce that NULL to zero.
+        if coalesce_to_zero {
+            Ok(build::cond::coalesce(vec![reference, build::value::zero()]))
+        } else {
+            Ok(reference)
+        }
     }
 
     fn get_cte_alias(&mut self) -> String {

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -991,6 +991,31 @@ WHERE
 
 ## Paths to many
 
+### Count of related records is coalesced to zero
+
+> Issues, showing the number of comments on each. An issue with no comments shows `0`, not NULL, because the count is coalesced to zero.
+
+```qd
+#issues $title $#comments
+```
+
+```sql
+WITH
+  "cte0" AS (
+    SELECT
+      "comments"."issue" AS "pk",
+      count(*) AS "v1"
+    FROM "comments"
+    GROUP BY "comments"."issue"
+  )
+SELECT
+  "issues"."title",
+  COALESCE("cte0"."v1", 0)
+FROM "issues"
+LEFT JOIN "cte0" ON
+  "issues"."id" = "cte0"."pk";
+```
+
 ### Path to many with column at end
 
 > Issues, showing the date of their most recent comment.
@@ -1035,7 +1060,7 @@ WITH
   )
 SELECT
   "issues"."id" AS "id",
-  "cte0"."v1" AS "total_comments_by_author"
+  COALESCE("cte0"."v1", 0) AS "total_comments_by_author"
 FROM "issues"
 LEFT JOIN "users" ON
   "issues"."author" = "users"."id"
@@ -1383,7 +1408,7 @@ WITH
     GROUP BY "issues"."author"
   )
 SELECT
-  "cte0"."v1"
+  COALESCE("cte0"."v1", 0)
 FROM "users"
 LEFT JOIN "cte0" ON
   "users"."id" = "cte0"."pk";
@@ -1899,7 +1924,7 @@ SELECT
   "issues"."title",
   "issues"."created_at",
   "issues"."due_date",
-  "cte0"."v1"
+  COALESCE("cte0"."v1", 0)
 FROM "issues"
 LEFT JOIN "cte0" ON
   "issues"."id" = "cte0"."pk";
@@ -2610,7 +2635,7 @@ WITH
       )
     SELECT
       "issues"."id" AS "id",
-      "cte0"."v1" AS "comment_count"
+      COALESCE("cte0"."v1", 0) AS "comment_count"
     FROM "issues"
     LEFT JOIN "cte0" ON
       "issues"."id" = "cte0"."pk"

--- a/compiler/src/tests/grouping.rs
+++ b/compiler/src/tests/grouping.rs
@@ -63,3 +63,19 @@ fn ungrouped_query_with_naked_column_is_allowed() {
     // Without any grouping, a plain column is fine.
     assert!(compile("#issues $title").is_ok());
 }
+
+#[test]
+fn count_of_related_records_is_coalesced_to_zero() {
+    // A to-many count is computed in a CTE joined via LEFT JOIN, so issues with no comments would
+    // otherwise yield NULL. The count is coalesced to zero so those rows show 0 instead.
+    let sql = compile("#issues $title $#comments").unwrap();
+    assert!(sql.contains("COALESCE(\"cte0\".\"v1\", 0)"), "got: {sql}");
+}
+
+#[test]
+fn non_count_aggregate_over_related_records_is_not_coalesced() {
+    // Only counts are coalesced to zero; a `max` over a to-many path should remain NULL when there
+    // are no related records.
+    let sql = compile("#issues $id $#comments.created_at%max").unwrap();
+    assert!(!sql.contains("COALESCE"), "got: {sql}");
+}

--- a/docs/language.md
+++ b/docs/language.md
@@ -720,6 +720,8 @@ In querydown (unlike SQL) all joined data is aggregated with respect to the base
 
 In our [example schema](#example-schema), each project has multiple issues. When the base table is `#projects`, the expression `#issues` means: _count the number of issues related to each project_.
 
+A project with no related issues shows `0` rather than NULL. Counts are always coalesced to zero so that the absence of related records reads as a count of zero.
+
 ### Specifying an aggregate function
 
 Specific aggregate functions can be applied via `%` (similar to pipe syntax).


### PR DESCRIPTION
## Summary

A query like `#issues $title $#comments` shows issue titles alongside the number of comments on each issue. Previously, an issue with no comments showed `NULL` in the count column. Now it shows `0`.

A to-many count is computed in a CTE that's joined back to the base table via a `LEFT JOIN`, so base-table rows with no related records yield `NULL`. This change coalesces such counts to zero so the absence of related records reads as a count of zero.

```sql
-- before
"cte0"."v1" AS "comment_count"
-- after
COALESCE("cte0"."v1", 0) AS "comment_count"
```

## Scope

- Applies to the bare to-many count (`$#comments`) as well as the `count` and `distinct` aggregate functions applied over a to-many path.
- Other aggregates (`max`, `sum`, `avg`, etc.) keep yielding `NULL` when there are no related records — only counts are coalesced.
- Counts in a grouped (`\g`) context are unaffected: they aggregate directly in the main query and never produce `NULL` from a missing join.

## Implementation

- `ValueViaCte`/`AggregateExprTemplate` now carry a `coalesce_to_zero` flag, set for count aggregates (`count`, `distinct`, and the bare to-many count).
- `Scope::join_chain_to_many` wraps the outer reference to the CTE value in `COALESCE(…, 0)` when that flag is set.

## Tests

- New corpus case asserting `#issues $title $#comments` coalesces the count to zero.
- New unit tests: one asserting a to-many count is coalesced, one asserting a `max` over a to-many path is *not* coalesced.
- Updated the four existing corpus cases whose selected count values now render with `COALESCE`.

Validated with `cargo check`, `cargo clippy`, `cargo build`, `cargo test`, and `cargo fmt`. The `db-tests` feature could not be exercised in this environment because the `postgres`/`duckdb` binaries are not installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKnR24HL2tRe79eaUnDpGh)_