### PR TITLE
Match empty string with strict equality

### DIFF
--- a/compiler/src/compiler/comparisons.rs
+++ b/compiler/src/compiler/comparisons.rs
@@ -167,9 +167,13 @@ fn convert_simple_comparison(
         Like => Ok(cmp::like(left_converted, right_converted)),
         RegexMatch => Ok(match_regex(left_converted, right_converted, scope)),
         // The match operator applies type-aware matching: case-insensitive "contains" when the
-        // left-hand side is known to be text, falling back to exact equality otherwise.
+        // left-hand side is known to be text, falling back to exact equality otherwise. An empty
+        // string literal on the right is a special case: "contains" would match every row, so we
+        // use strict equality instead, making `description:""` find rows with an empty description
+        // (mirroring `description:=""`).
         Match => {
-            if classify_value_type(left, scope) == ValueType::Text {
+            let right_is_empty_string = matches!(right, Expr::String(s) if s.is_empty());
+            if !right_is_empty_string && classify_value_type(left, scope) == ValueType::Text {
                 Ok(scope
                     .options
                     .dialect

--- a/compiler/src/tests/corpus.md
+++ b/compiler/src/tests/corpus.md
@@ -578,6 +578,26 @@ WHERE
   COALESCE(contains(lower(strip_accents("issues"."title")), lower(strip_accents('performance'))), FALSE);
 ```
 
+### Text match against an empty string is exact equality
+
+An empty string literal on the right-hand side of `:` is matched via strict equality rather than
+"contains" (which would match every row). This makes `description:""` find rows with an empty
+description, the same as the explicit `description:=""`.
+
+> Issues with an empty description
+
+```qd
+#issues description:""
+```
+
+```sql
+SELECT
+  "issues".*
+FROM "issues"
+WHERE
+  "issues"."description" = '';
+```
+
 ### Explicit equality on text
 
 The `:=` operator forces exact equality, even for text columns.

--- a/docs/language.md
+++ b/docs/language.md
@@ -318,6 +318,8 @@ This does a case-insensitive search for "performance" anywhere in the issue titl
 
 The match comparison operator (`:`) behaves differently according to the type of expression on the left-hand-side. Text values will match via contains logic, while other values (e.g. numbers, dates, etc) are compared using strict equality.
 
+As a special case, matching a text value against an **empty string** uses strict equality rather than contains logic (which would otherwise match every row). This means `#issues description:""` finds issues with an empty description, the same as `#issues description:=""`.
+
 ### Equality comparisons
 
 > Find issues where the status exactly equals "do"


### PR DESCRIPTION
## Summary

The match operator (`:`) does a case-insensitive "contains" search when the left-hand side is a text column. Matching against an empty string this way (`#issues description:""`) matched every row, because every string contains the empty string — not useful.

This change makes an **empty string literal** on the right-hand side of `:` fall back to **strict equality**. So `#issues description:""` now finds issues with an empty description, which is the more intuitive behavior the user expected (and matches what `#issues description:=""` already did).

## Changes

- `compiler/src/compiler/comparisons.rs`: in the `Match` arm of `convert_simple_comparison`, detect an empty string literal on the right-hand side and use `cmp::eq` instead of the dialect's `text_contains`.
- `compiler/src/tests/corpus.md`: added a corpus test "Text match against an empty string is exact equality" verifying `#issues description:""` compiles to `"issues"."description" = ''`.
- `docs/language.md`: documented the empty-string special case in the "Match comparisons" section.

## Testing

- `cargo check`, `cargo clippy`, `cargo build`, `cargo test`, `cargo fmt` all pass.
- The new corpus test passes (`cargo test tests::corpus`).
- `cargo test --features db-tests` was not exercised here because the `postgres`/`duckdb` binaries are not present in this environment; the non-db corpus test still validates the generated SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdJ2X8Tb1nRYshYUgUyCXa)_